### PR TITLE
Add uTP message format

### DIFF
--- a/discv5-utp.md
+++ b/discv5-utp.md
@@ -27,6 +27,13 @@ Bob, upon receiving the `Data` message containing the `connection_id` will
 When this new connection is opened, Alice can then read the bytes from the stream
 until the connection closes.
 
+### Message format
+
+| Bytes | Fields     | Description                            |
+|-------|------------|----------------------------------------|
+| 4     | length     | length of the payload in BE format     |
+| ?     | payload    | bytelist of data                       |
+
 ## BEP29
 
 https://www.bittorrent.org/beps/bep_0029.html


### PR DESCRIPTION
So I am making this PR because I would like to standardize a messaging format for sending data over uTP or start working towards it. Currently there is nothing in the spec for handing this, except for the idea of streaming data which is very vague. I propose we follow a format something like this.

| Bytes | Fields     | Description                            |
|-------|------------|----------------------------------------|
| 1     | message_id | The message_id of the response         |
| 5     | length     | length of the payload                  |
| ?     | payload    | the data of the response encoded in ssz|

I am suggesting we add a message_id and length prefix as a header for the data we send over uTP.

- message_id would allow us to handle the data sent over uTP stream using an event loop ethereum/trin#102 there are good arguments for it. 2 benefits of it is that it is simple and less added complexity to name a few. I do think it would be beneficial for this and others have expressed this in the issue listed above as well.
- length would allow of to know when we have received all of the data being streamed so we can handle it and eventually close the connection if wanted when we have received it all.

![image](https://user-images.githubusercontent.com/31669092/138381133-6aa6a09d-b16a-48ba-b86f-0ecc94f956ca.png)

For this I propose we could add a checksum or something using the first few bytes of a keccak or sha256 hash of the payload. Or maybe you meant like making sure they sent actually valid data which would be handled in the handler I would assume.