### PR TITLE
Beacon chain spec

### DIFF
--- a/beacon-chain/README.md
+++ b/beacon-chain/README.md
@@ -1,0 +1,11 @@
+## Status
+>  All specifications in this directory is a work-in-progress and should be considered preliminary.
+
+## Beacon Chain Light Client
+The networks described in this directory are intended to support beacon chain light clients.
+
+See discussion on how to [classify](https://ethresear.ch/t/beacon-chain-light-client-classification/11061
+) beacon chain light clients.
+
+- Minimal light client [spec](https://github.com/ethereum/consensus-specs/blob/a20f6f7b5f40292c2a864337336bff74ae318354/specs/altair/sync-protocol.md#altair----minimal-light-client)
+- A [proposal](https://ethresear.ch/t/a-beacon-chain-light-client-proposal/11064) for a light client that supports APIs on beacon chain state.

--- a/beacon-chain/beacon-state-dht.md
+++ b/beacon-chain/beacon-state-dht.md
@@ -1,0 +1,81 @@
+## DHT Overview
+A client has a trusted beacon state root, and it wants to access some parts of the state. Each of the access request corresponds to some leave nodes of the beacon state. The request is a content lookup on a DHT. The response is a Merkle proof. 
+
+A Distributed Hash Table (DHT) allows network participants to have retrieve data on-demand based on a content key. A portal-network DHT is different than a traditional one in that each participant could selectively limit its workload by choosing a small <em>interest radius</em> `r`. A participants only process messages that are within its chosen radius boundary.
+
+The beacon state DHT shares all the basic structures as other DHT networks, e.g. the [state network](state-network.md). A DHT uses the message types PING, PONG, FINDNODES, NODES, FINDCONTENT, and CONTENT. The message encodings are specified in the [portal wire protocol](../portal-wire-protocol.md).
+
+This DHT is part of a [proposal](https://ethresear.ch/t/a-beacon-chain-light-client-proposal/11064) for a beacon chain light client.
+
+The subprotocol id is: `0x501C`.
+
+
+## Wire Protocol
+For a subprotocol, we need to further define the following to be able to instantiate the wire format of each message type.
+1. `content_key`
+1. `content_id` 
+1. `payload`
+
+The content of the message is a Merkle proof contains multiple leave nodes for a [BeaconState](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#beaconstate).
+
+```python
+class BeaconState(Container):
+    """
+    See: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#beaconstate
+    """
+    pass
+
+# Used to limit the size of the message. This could be modified to be higher if needed.
+LEAVE_ITEM_LIMIT = 128
+
+# The maximum number of proof nodes needed to complete a merkle proof
+# Note that max_chuck_count() is recursively apply chunk_count() on all possible paths of the BeaconState.
+HELPER_INDICES_LIMIT = LEAVE_ITEM_LIMIT * log(max_chuck_count(BeaconState))  
+
+class BeaconStateProof(Container):
+    """
+    See: https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs
+    """
+    root: Bytes323
+    leave_indices: List[unit64, LEAVE_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
+    leaves: List[Bytes32, LEAVE_ITEM_LIMIT]
+    proof_nodes: List[Bytes32, HELPER_INDICES_LIMIT]
+```
+
+Finally, we define the necessary encodings. A light client only knows the root of the beacon state. The client wants to know the details of some leave nodes. The client has to be able to construct the `content_key` only knowing the root and which leave nodes it wants see. The `content_key` is the ssz serialization of the paths. The paths represent the part of the beacon state that one wants to know about. The paths are represented by generalized indices. Note that `hash_tree_root` and `serialize` are the same as those defined in [sync-gossip](sync-gossip.md). 
+
+```python
+class BeaconStateProofKey(Container):
+    root: Bytes323
+    leave_indices: List[unit64, LEAVE_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
+
+
+def get_generalized_index(typ: SSZType, path: Sequence[Union[int, SSZVariableName]]) -> GeneralizedIndex:
+    """
+    Converts a path (eg. `[7, "foo", 3]` for `x[7].foo[3]`, `[12, "bar", "__len__"]` for
+    `len(x[12].bar)`) into the generalized index representing its position in the Merkle tree.
+
+    See: https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#ssz-object-to-index
+    """
+    pass
+
+
+def get_content_key(root: Bytes323, paths: Sequence[Sequence[[Union[int, SSZVariableName]]]) -> bytes:
+    indices = [get_generalized_index(BeaconSate, path) for path in paths]
+    proof_key = BeaconStateProofKey()
+    proof_key.root = root
+    proof_key.leave_indices = indices
+    return serialize(BeaconStateProofKey, proof_key)
+
+
+content_key := get_content_key(root, paths)
+content_id := hash_tree_root(BeaconStateProof, beacon_state_proof)
+payload := serialize(BeaconStateProof, beacon_state_proof)
+```
+
+
+## TODOs
+- Determine if the message type `BeaconStateProof` needs to be gossiped as well.
+- The DHT algorithm for `FINDCONTENT` might not reach large radius node, and hence it would fail to find some available contents. See the [discussion](https://github.com/ethereum/portal-network-specs/issues/91)
+
+

--- a/beacon-chain/beacon-state-network.md
+++ b/beacon-chain/beacon-state-network.md
@@ -78,4 +78,3 @@ payload := serialize(BeaconStateProof, beacon_state_proof)
 - Determine if the message type `BeaconStateProof` needs to be gossiped as well.
 - The DHT algorithm for `FINDCONTENT` might not reach large radius node, and hence it would fail to find some available contents. See the [discussion](https://github.com/ethereum/portal-network-specs/issues/91)
 
-

--- a/beacon-chain/beacon-state-network.md
+++ b/beacon-chain/beacon-state-network.md
@@ -68,9 +68,9 @@ def get_content_key(root: Bytes323, paths: Sequence[Sequence[[Union[int, SSZVari
     return serialize(BeaconStateProofKey, proof_key)
 
 
-content_key := get_content_key(root, paths)
-content_id := hash_tree_root(BeaconStateProof, beacon_state_proof)
-payload := serialize(BeaconStateProof, beacon_state_proof)
+content_key = get_content_key(root, paths)
+content_id = hash_tree_root(BeaconStateProof, beacon_state_proof)
+payload = serialize(BeaconStateProof, beacon_state_proof)
 ```
 
 

--- a/beacon-chain/sync-gossip.md
+++ b/beacon-chain/sync-gossip.md
@@ -1,0 +1,94 @@
+## Overview
+A beacon chain client could sync committee to perform [state updates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md). The data object [LightClientSnapshot](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientsnapshot) allows a client to quickly sync to a particular header. Once the client establishes a valid header, it could sync to other headers by processing [LightClientUpdates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientupdate). These two data types allow a client to stay up-to-date with the beacon chain.
+
+These two data types are placed into separate gossip topics. A light client only needs to connects to `bc-light-client-snapshot` briefly at the start of the sync to get a reasonably recent beacon chain header. The client uses messages in the topic `bc-light-client-update` to advance its header.
+
+The gossip topics described in this document is part of a [proposal](https://ethresear.ch/t/a-beacon-chain-light-client-proposal/11064) for a beacon chain light client.
+
+
+## Gossip Network
+A gossip network allows participants to receive regular updates on a particular data type. The key point of differentiation between a portal network gossip channel and a regular gossip channel, e.g. the gossip topic `beacon_block` used by regular beacon chain clients, is that a portal network participant could choose an <em>interest radius</em> `r`. A participants only process messages that are within its chosen radius boundary.
+
+The gossip network shares all the basic structures as other gossip networks, e.g. the [transaction gossip](../transaction-gossip.md).
+
+- Each gossip participant has a `node_id`. A `node_id` is a 256 bit unsigned integer, i.e. `0 <= node_id < 2**256`.
+- Each message has a `content_id`. A `content_id` is a 256 bit unsigned integer.
+- There is a distance function. It measures the distance between two `node_id`. It also measures the distance between `node_id` and `content_id`.
+    ```python
+    def distance(node_id: int, content_id: int) -> int:
+        """See TODOs"""
+        pass
+    ```
+
+## Wire Protocol
+The [portal wire protocol](../portal-wire-protocol.md) specifies the generic wire formats of each of message type: PING, PONG, FINDNODES, FOUNDNODES, OFFER, and ACCEPT. For a subprotocol, we need to further define the following to be able to instantiate a type's byte contents.
+1. `subprotocol id`
+1. `content_key`
+1. `content_id` 
+1. `payload`
+
+The following helper functions are defined in [ssz spec](https://github.com/ethereum/consensus-specs/blob/dev/ssz/). A SszObject is an object that is a valid [ssz typing](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#typing).
+```python
+def serialize(typ: SszType, obj: SszObject) -> bytes
+def hash_tree_root(typ: SszType, obj: SszObject) -> bytes
+```
+
+See [serialization](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#serialization) and [merkleiation]((https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization)) for more details.
+
+#### bc-light-client-snapshot
+The subprotocol id is: `0x501A`.
+
+The content of the message is the [snapshot container](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientsnapshot) object.
+```python
+class LightClientSnapshot(Container):
+    # Beacon block header
+    header: BeaconBlockHeader
+    # Sync committees corresponding to the header
+    current_sync_committee: SyncCommittee
+    next_sync_committee: SyncCommittee
+```
+
+Finally, we define the necessary encodings. Note that one could not construct the `content_key` without knowing having already has the object. It might be advantageous to allow `content_key` to retain information about its epoch or slot, but none of the those markers would be able to uniquely identifies a snapshot object. Using a content addressable hash as the `content_key` is choice for simplicity.
+```python
+content_key := hash_tree_root(LightClientSnapshot, light_client_snapshot)
+content_id := content_key
+payload := serialize(LightClientSnapshot, light_client_snapshot)
+```
+
+
+#### bc-light-client-update
+The subprotocol id is: `0x502A`.
+
+The content of the message is the [update container](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientupdate).
+```python
+class LightClientUpdate(Container):
+    # Update beacon block header
+    header: BeaconBlockHeader
+    # Next sync committee corresponding to the header
+    next_sync_committee: SyncCommittee
+    next_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_INDEX)]
+    # Finality proof for the update header
+    finality_header: BeaconBlockHeader
+    finality_branch: Vector[Bytes32, floorlog2(FINALIZED_ROOT_INDEX)]
+    # Sync committee aggregate signature
+    sync_committee_bits: Bitvector[SYNC_COMMITTEE_SIZE]
+    sync_committee_signature: BLSSignature
+    # Fork version for the aggregate signature
+    fork_version: Version
+```
+
+Finally, we define the necessary encodings.
+```python
+content_key := hash_tree_root(LightClientUpdate, light_client_update)
+content_id := content_key
+payload := serialize(LightClientUpdate, light_client_update)
+```
+
+## TODOs
+- A client should receive at least one LightClientSnapshot message within a sync committee period. There should be a minimal radius recommended such that the client rarely has to connect to `bc-light-client-snapshot` to update its head due to missing an entire sync committee period. This value could be determined empirically.
+
+- It makes sense that there should a single distance function that works for all portal network subnetworks. The proposed [distance function](https://github.com/ethereum/portal-network-specs/blob/master/state-network.md#distance-function) is defined to be the distance in a ring might not [work well](https://github.com/ethereum/portal-network-specs/issues/90) for a Kademlia DHT.
+
+- Define the routing table algorithm. If the distance measure is XOR, the routing table should be maintained as Kademlia routing table. Otherwise, define how the routing table is maintained.
+
+- Define the gossip algorithm. The portal network gossip channel uses radius `r` as an additional control to how messages are propagated. A node uses `r` to determine which messages to forward to which peers. See discussions in this [issue](https://github.com/ethereum/portal-network-specs/issues/89). Transaction-gossip is attempting to define an [algorithm](transaction-gossip.md#gossip-algorithm). There should be a generic gossip algorithm that works for all portal network gossip channels.

--- a/beacon-chain/sync-gossip.md
+++ b/beacon-chain/sync-gossip.md
@@ -53,9 +53,9 @@ class LightClientSnapshot(Container):
 
 Finally, we define the necessary encodings. Note that one could not construct the `content_key` without knowing having already has the object. It might be advantageous to allow `content_key` to retain information about its epoch or slot, but none of the those markers would be able to uniquely identifies a snapshot object. Using a content addressable hash as the `content_key` is choice for simplicity.
 ```python
-content_key := hash_tree_root(LightClientSnapshot, light_client_snapshot)
-content_id := content_key
-payload := serialize(LightClientSnapshot, light_client_snapshot)
+content_key = hash_tree_root(LightClientSnapshot, light_client_snapshot)
+content_id = content_key
+payload = serialize(LightClientSnapshot, light_client_snapshot)
 ```
 
 
@@ -82,9 +82,9 @@ class LightClientUpdate(Container):
 
 Finally, we define the necessary encodings.
 ```python
-content_key := hash_tree_root(LightClientUpdate, light_client_update)
-content_id := content_key
-payload := serialize(LightClientUpdate, light_client_update)
+content_key = hash_tree_root(LightClientUpdate, light_client_update)
+content_id = content_key
+payload = serialize(LightClientUpdate, light_client_update)
 ```
 
 ## TODOs

--- a/beacon-chain/sync-gossip.md
+++ b/beacon-chain/sync-gossip.md
@@ -1,3 +1,6 @@
+## Status
+>  This specification is a work-in-progress and should be considered preliminary.
+
 ## Overview
 A beacon chain client could sync committee to perform [state updates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md). The data object [LightClientSnapshot](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientsnapshot) allows a client to quickly sync to a particular header. Once the client establishes a valid header, it could sync to other headers by processing [LightClientUpdates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientupdate). These two data types allow a client to stay up-to-date with the beacon chain.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -22,6 +22,9 @@ Currently defined protocol identifiers:
 - `0x500C`: Transaction Gossip Network
 - `0x500D`: Header Gossip Network
 - `0x500E`: Canonical Indices Network
+- `0x501A`: gossip channel: bc-light-client-snapshot
+- `0x501B`: gossip channel: bc-light-client-update
+- `0x501C`: DHT network: beacon-state
 
 ## Content Keys and Content IDs
 


### PR DESCRIPTION
This spec PR proposes two new sub-networks. One is for syncing headers of the beacon state, and the other is for asking questions about the state.

The main part of the PR is about the message formats of each sub-networks. It primarily leverages SSZ. The networking layer follows the portal network protocol.