### PR TITLE
Skip sync and initial sync

### DIFF
--- a/beacon-chain/beacon-state-network.md
+++ b/beacon-chain/beacon-state-network.md
@@ -32,6 +32,7 @@ LEAVE_ITEM_LIMIT = 128
 # Note that max_chuck_count() is recursively apply chunk_count() on all possible paths of the BeaconState.
 HELPER_INDICES_LIMIT = LEAVE_ITEM_LIMIT * log(max_chuck_count(BeaconState))  
 
+
 class BeaconStateProof(Container):
     """
     See: https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs
@@ -39,7 +40,7 @@ class BeaconStateProof(Container):
     root: Bytes323
     leave_indices: List[unit64, LEAVE_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
     leaves: List[Bytes32, LEAVE_ITEM_LIMIT]
-    proof_nodes: List[Bytes32, HELPER_INDICES_LIMIT]
+    branches: List[Bytes32, HELPER_INDICES_LIMIT]
 ```
 
 Finally, we define the necessary encodings. A light client only knows the root of the beacon state. The client wants to know the details of some leave nodes. The client has to be able to construct the `content_key` only knowing the root and which leave nodes it wants see. The `content_key` is the ssz serialization of the paths. The paths represent the part of the beacon state that one wants to know about. The paths are represented by generalized indices. Note that `hash_tree_root` and `serialize` are the same as those defined in [sync-gossip](sync-gossip.md). 

--- a/beacon-chain/skip-sync-network.md
+++ b/beacon-chain/skip-sync-network.md
@@ -52,6 +52,6 @@ payload = serialize(SkipSyncUpdate, skip_sync_update)
 - The rule for picking the update within a sync period is as followed:
     1. The finalized update with the highest participation
     2. The update with highest participation
-    3. Prefer the most recent update
-- Clients do not need to retrieve the exact same `skip_sync_update` while making requests with the same `skip_sync_update_key`. They only need to receive a valid `skip_sync_update` that allows them to advance their head to the next sync committee.
+    3. Prefer the oldest update
+- Clients do not need to retrieve the exact same `skip_sync_update` while making requests with the same `skip_sync_update_key`. They only need to receive a valid `skip_sync_update` that allows them to advance their head to the next sync committee period.
 - `SkipSyncUpdate` is different from `LightClientUpdate` in that `sync_committee` is present in the skip sync update message. This inclusion allows portal network nodes to validate the message without any external dependencies. The original data lookup requester has the sync-committee, but network nodes are not required to keep the database of historical `SkipSyncUpdate`. If a portal network node does not validate `SkipSyncUpdate` messages before propagating, the DHT could be easily polluted with key-value pair (`skip_sync_update_key`, `skip_sync_update`) that are not internally consistent. Even a small number of bad messages could amplify to be the dominant answers of a data lookup if those bad messages were the first messages to enter the DHT.

--- a/beacon-chain/skip-sync-network.md
+++ b/beacon-chain/skip-sync-network.md
@@ -3,13 +3,13 @@
 
 
 ## DHT Overview
-A client uses `LightClientSkipSyncUpdate` to skip sync from a known header to a recent header. A client with a trusted but outdated header cannot use the messages in the gossip channel `bc-light-client-update` to update. The client's sync-committee in the stored snapshot is too old and not connected to any update messages. The client look for the appropriate `LightClientSkipSyncUpdate` to skip sync its header.
+A client uses `SkipSyncUpdate` to skip sync from a known header to a recent header. A client with a trusted but outdated header cannot use the messages in the gossip channel `bc-light-client-update` to update. The client's sync-committee in the stored snapshot is too old and not connected to any update messages. The client look for the appropriate `SkipSyncUpdate` to skip sync its header.
 
 The subprotocol id is: `0x501A`.
 
 
 ## Wire Protocol
-The wire protocol](../portal-wire-protocol.md) specifies the generic wire formats of each of message type: PING, PONG, FINDNODES, FOUNDNODES, OFFER, ACCEPT, FINDCONTENT, and CONTENT. Defining the following functions allow the client to construct the wire formats of the message type `LightClientSkipSyncUpdate`.
+The wire protocol](../portal-wire-protocol.md) specifies the generic wire formats of each of message type: PING, PONG, FINDNODES, FOUNDNODES, OFFER, ACCEPT, FINDCONTENT, and CONTENT. Defining the following functions allow the client to construct the wire formats of the message type `SkipSyncUpdate`.
 
 1. `content_key`
 1. `content_id` 
@@ -17,37 +17,41 @@ The wire protocol](../portal-wire-protocol.md) specifies the generic wire format
 
 
 ```python
-class LightClientSkipSyncUpdate(Container):
+class SkipSyncUpdate(Container):
     # Update beacon block header
     header: BeaconBlockHeader
-    # Current sync committee corresponding to the header
-    current_sync_committee: SyncCommittee
-    current_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_INDEX)]
     # Next sync committee corresponding to the header
     next_sync_committee: SyncCommittee
     next_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_INDEX)]
+    # Finality proof for the update header
+    finality_header: BeaconBlockHeader
+    finality_branch: Vector[Bytes32, floorlog2(FINALIZED_ROOT_INDEX)]
     # Sync committee aggregate signature
+    sync_committee: SyncCommittee
     sync_committee_bits: Bitvector[SYNC_COMMITTEE_SIZE]
     sync_committee_signature: BLSSignature
     # Fork version for the aggregate signature
     fork_version: Version
 
 class SkipSyncUpdateKey(Container):
-    epoch: Epoch
-    next_sync_committee: SyncCommittee
-    fork_version: Version
+    sync_committee: SyncCommittee
 
-def get_content_key(epoch: Epoch, next_sync_committee SyncCommittee, fork_version Version) -> bytes:
-    indices = [get_generalized_index(BeaconSate, path) for path in paths]
+def get_content_key(epoch: Epoch, sync_committee SyncCommittee) -> bytes:
     key = SkipSyncUpdateKey()
-    key.epoch = epoch
-    key.next_sync_committee = next_sync_committee
-    key.fork_version = fork_version
+    key.sync_committee = sync_committee
 
-    return serialize(SkipSyncUpdateKey, key)
+    return hash_tree_root(SkipSyncUpdateKey, key)
 
-content_key = get_content_key(epoch, current_sync_committee, next_sync_committee)
+content_key = get_content_key(epoch, sync_committee)
 content_id = hash_tree_root(SkipSyncUpdateKey, skip_sync_update_key)
-payload = serialize(LightClientSkipSyncUpdate, LightClientSkipSyncUpdate)
+payload = serialize(SkipSyncUpdate, skip_sync_update)
 ```
 
+## Notes
+- A node maintains a database of historical `SkipSyncUpdate`. It keeps one update per sync period. These updates are keyed by the `skip_sync_update_key`, effectively by the hash of sync-committee.
+- The rule for picking the update within a sync period is as followed:
+    1. The finalized update with the highest participation
+    2. The update with highest participation
+    3. Prefer the most recent update
+- Clients do not need to retrieve the exact same `skip_sync_update` while making requests with the same `skip_sync_update_key`. They only need to receive a valid `skip_sync_update` that allows them to advance their head to the next sync committee.
+- `SkipSyncUpdate` is different from `LightClientUpdate` in that `sync_committee` is present in the skip sync update message. This inclusion allows portal network nodes to validate the message without any external dependencies. The original data lookup requester has the sync-committee, but network nodes are not required to keep the database of historical `SkipSyncUpdate`. If a portal network node does not validate `SkipSyncUpdate` messages before propagating, the DHT could be easily polluted with key-value pair (`skip_sync_update_key`, `skip_sync_update`) that are not internally consistent. Even a small number of bad messages could amplify to be the dominant answers of a data lookup if those bad messages were the first messages to enter the DHT.

--- a/beacon-chain/skip-sync-network.md
+++ b/beacon-chain/skip-sync-network.md
@@ -34,15 +34,13 @@ class LightClientSkipSyncUpdate(Container):
 
 class SkipSyncUpdateKey(Container):
     epoch: Epoch
-    current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee
     fork_version: Version
 
-def get_content_key(epoch: Epoch, current_sync_committee SyncCommittee, next_sync_committee SyncCommittee, fork_version Version) -> bytes:
+def get_content_key(epoch: Epoch, next_sync_committee SyncCommittee, fork_version Version) -> bytes:
     indices = [get_generalized_index(BeaconSate, path) for path in paths]
     key = SkipSyncUpdateKey()
     key.epoch = epoch
-    key.current_sync_committee = current_sync_committee
     key.next_sync_committee = next_sync_committee
     key.fork_version = fork_version
 

--- a/beacon-chain/skip-sync-network.md
+++ b/beacon-chain/skip-sync-network.md
@@ -1,0 +1,55 @@
+## Status
+>  This specification is a work-in-progress and should be considered preliminary.
+
+
+## DHT Overview
+A client uses `LightClientSkipSyncUpdate` to skip sync from a known header to a recent header. A client with a trusted but outdated header cannot use the messages in the gossip channel `bc-light-client-update` to update. The client's sync-committee in the stored snapshot is too old and not connected to any update messages. The client look for the appropriate `LightClientSkipSyncUpdate` to skip sync its header.
+
+The subprotocol id is: `0x501A`.
+
+
+## Wire Protocol
+The wire protocol](../portal-wire-protocol.md) specifies the generic wire formats of each of message type: PING, PONG, FINDNODES, FOUNDNODES, OFFER, ACCEPT, FINDCONTENT, and CONTENT. Defining the following functions allow the client to construct the wire formats of the message type `LightClientSkipSyncUpdate`.
+
+1. `content_key`
+1. `content_id` 
+1. `payload`
+
+
+```python
+class LightClientSkipSyncUpdate(Container):
+    # Update beacon block header
+    header: BeaconBlockHeader
+    # Current sync committee corresponding to the header
+    current_sync_committee: SyncCommittee
+    current_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_INDEX)]
+    # Next sync committee corresponding to the header
+    next_sync_committee: SyncCommittee
+    next_sync_committee_branch: Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_INDEX)]
+    # Sync committee aggregate signature
+    sync_committee_bits: Bitvector[SYNC_COMMITTEE_SIZE]
+    sync_committee_signature: BLSSignature
+    # Fork version for the aggregate signature
+    fork_version: Version
+
+class SkipSyncUpdateKey(Container):
+    epoch: Epoch
+    current_sync_committee: SyncCommittee
+    next_sync_committee: SyncCommittee
+    fork_version: Version
+
+def get_content_key(epoch: Epoch, current_sync_committee SyncCommittee, next_sync_committee SyncCommittee, fork_version Version) -> bytes:
+    indices = [get_generalized_index(BeaconSate, path) for path in paths]
+    key = SkipSyncUpdateKey()
+    key.epoch = epoch
+    key.current_sync_committee = current_sync_committee
+    key.next_sync_committee = next_sync_committee
+    key.fork_version = fork_version
+
+    return serialize(SkipSyncUpdateKey, key)
+
+content_key = get_content_key(epoch, current_sync_committee, next_sync_committee)
+content_id = hash_tree_root(SkipSyncUpdateKey, skip_sync_update_key)
+payload = serialize(LightClientSkipSyncUpdate, LightClientSkipSyncUpdate)
+```
+

--- a/beacon-chain/sync-gossip.md
+++ b/beacon-chain/sync-gossip.md
@@ -2,9 +2,9 @@
 >  This specification is a work-in-progress and should be considered preliminary.
 
 ## Overview
-A beacon chain client could sync committee to perform [state updates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md). The data object [LightClientSkipSyncUpdate](skip-sync-network) allows a client to quickly sync to a reasonably recent header. Once the client establishes a recent header, it could sync to other headers by processing [LightClientUpdates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientupdate). These two data types allow a client to stay up-to-date with the beacon chain.
+A beacon chain client could sync committee to perform [state updates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md). The data object [LightClientSkipSyncUpdate](skip-sync-network) allows a client to quickly sync to a recent header with the appropriate sync committee. Once the client establishes a recent header, it could sync to other headers by processing [LightClientUpdates](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/sync-protocol.md#lightclientupdate). These two data types allow a client to stay up-to-date with the beacon chain.
 
-These two data types are placed into separate gossip topics. A light client make find-content requests on `skip-sync-network` at start of the sync to get a reasonably recent beacon chain header. The client uses messages in the gossip topic `bc-light-client-update` to advance its header.
+These two data types are placed into separate sub-networks. A light client make find-content requests on `skip-sync-network` at start of the sync to get a header with the same `SyncCommittee` object as in the current sync period. The client uses messages in the gossip topic `bc-light-client-update` to advance its header.
 
 The gossip topics described in this document is part of a [proposal](https://ethresear.ch/t/a-beacon-chain-light-client-proposal/11064) for a beacon chain light client.
 


### PR DESCRIPTION
This modifies the spec to address some issues raised in the previous PR
https://github.com/ethereum/portal-network-specs/pull/99

1. How to initialize the first sync?
2. What happen if a client has an outdated snapshot?
