### PR TITLE
Add test vectors for uTP encoding/decoding

### DIFF
--- a/utp-wire-test-vectors.md
+++ b/utp-wire-test-vectors.md
@@ -1,0 +1,185 @@
+# Utp Wire Test Vectors
+
+This document provides a collection of test vectors for encoding and decoding
+uTP protocol packets
+
+## Utp Packets Encodings
+
+This section provides test vectors for the individual protocol packets defined in
+uTP specification - https://www.bittorrent.org/beps/bep_0029.html.
+
+Each packet input parameters are - `(PacketHeader, List[Extension], payload)`
+
+Altough spec defines only one extension called - `SelectiveAckExtension`
+
+Taking that into account, packet inputs can be simplified to - `(PacketHeader, Option[SelectiveAckExtension], Payload)`
+
+Where:
+`payload` is an `ByteArray`
+
+`PacketHeader` is object with input paramaters - 
+`(type, version, extension, connection_id, timestamp_microseconds, timestamp_difference_microseconds, wnd_size, seq_nr, ack_nr)`
+
+`Option[SelectiveAckExtension]` is either, bitmask of 32bits where each bit represents one packet in the send window
+or none value which represent lack of any extension.
+
+### SYN Packet
+
+#### Input Parameters
+
+```
+PacketHeader = {
+  type: 4
+  version: 1
+  extension: 0
+  connection_id: 10049
+  timestamp_microseconds: 3384187322
+  timestamp_difference_microseconds: 0
+  wnd_size: 1048576
+  seq_nr: 11884
+  ack_nr: 0
+}
+
+SelectiveAckExtension = none
+Payload = []
+```
+
+#### Expected Output
+```
+packet = 0x41002741c9b699ba00000000001000002e6c0000
+```
+
+### Ack Packet (no extension)
+
+#### Input Parameters
+
+```
+PacketHeader = {
+  type: 2
+  version: 1
+  extension: 0
+  connection_id: 10049
+  timestamp_microseconds: 6195294
+  timestamp_difference_microseconds: 916973699
+  wnd_size: 1048576
+  seq_nr: 16807
+  ack_nr: 11885
+}
+
+SelectiveAckExtension = none
+Payload = []
+```
+
+#### Expected Output
+```
+packet = 0x21002741005e885e36a7e8830010000041a72e6d
+```
+
+
+### Ack Packet (with selective ack extension)
+
+#### Input Parameters
+
+```
+PacketHeader = {
+  type: 2
+  version: 1
+  extension: 1
+  connection_id: 10049
+  timestamp_microseconds: 6195294
+  timestamp_difference_microseconds: 916973699
+  wnd_size: 1048576
+  seq_nr: 16807
+  ack_nr: 11885
+}
+
+SelectiveAckExtension = [1, 0, 0, 128] // bitmask with 0 and 31 bit set
+Payload = []
+```
+
+#### Expected Output
+```
+packet = 0x21012741005e885e36a7e8830010000041a72e6d000401000080
+```
+
+
+### DATA Packet
+
+#### Input Parameters
+
+```
+PacketHeader = {
+  type: 0
+  version: 1
+  extension: 0
+  connection_id: 26237
+  timestamp_microseconds: 252492495
+  timestamp_difference_microseconds: 242289855
+  wnd_size: 1048576
+  seq_nr: 8334
+  ack_nr: 16806
+}
+
+SelectiveAckExtension = none
+Payload = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+```
+
+#### Expected Output
+```
+packet = 0x0100667d0f0cbacf0e710cbf00100000208e41a600010203040506070809
+```
+
+
+### FIN Packet
+
+#### Input Parameters
+
+```
+PacketHeader = {
+  type: 1
+  version: 1
+  extension: 0
+  connection_id: 19003
+  timestamp_microseconds: 515227279
+  timestamp_difference_microseconds: 511481041
+  wnd_size: 1048576
+  seq_nr: 41050
+  ack_nr: 16806
+}
+
+SelectiveAckExtension = none
+Payload = []
+```
+
+#### Expected Output
+```
+packet = 0x11004a3b1eb5be8f1e7c94d100100000a05a41a6
+```
+
+
+### RESET Packet
+
+#### Input Parameters
+
+```
+PacketHeader = {
+  type: 3
+  version: 1
+  extension: 0
+  connection_id: 62285
+  timestamp_microseconds: 751226811
+  timestamp_difference_microseconds: 0
+  wnd_size: 0
+  seq_nr: 55413
+  ack_nr: 16807
+}
+
+SelectiveAckExtension = none
+Payload = []
+```
+
+#### Expected Output
+```
+packet = 0x3100f34d2cc6cfbb0000000000000000d87541a7
+```
+


### PR DESCRIPTION
Add test vectors for utp packets decoding and encoding. Most of of packets was generated by interaction with utp reference implementation.