### PR TITLE
Updates to state network spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,55 @@ These design principles are aimed at ensuring that participation in the Portal N
 
 ## The JSON-RPC API
 
-The following JSON-RPC API endpoints are intended to be supported by the portal network and exposed by portal clients.
+The following JSON-RPC API endpoints are directly supported by the portal network and exposed by portal clients.
+
+- `eth_getBlockByHash`
+- `eth_getBlockByNumber`
+- `eth_getBlockTransactionCountByHash`
+- `eth_getBlockTransactionCountByNumber`
+- `eth_getUncleCountByBlockHash`
+- `eth_getUncleCountByBlockNumber`
+- `eth_blockNumber`
+- `eth_call`
+- `eth_estimateGas`
+- `eth_getBalance`
+- `eth_getStorageAt`
+- `eth_getTransactionCount`
+- `eth_getCode`
+- `eth_sendRawTransaction`
+- `eth_getTransactionByHash`
+- `eth_getTransactionByBlockHashAndIndex`
+- `eth_getTransactionByBlockNumberAndIndex`
+- `eth_getTransactionReceipt`
+
+In addition to these endpoints, the following endpoints can be exposed by portal clients through the data available through the portal network.
+
+- `eth_syncing`
+
+The following endpoints can be exposed by portal clients as they require no access to execution layer data.
+
+- `eth_protocolVersion`
+- `eth_chainId`
+- `eth_coinbase`
+- `eth_accounts`
+- `eth_gasPrice`
+- `eth_feeHistory`
+- `eth_newFilter`
+  - TODO: explain complexity.
+- `eth_newBlockFilter`
+- `eth_newPendingTransactionFilter`
+- `eth_uninstallFilter`
+- `eth_getFilterChanges`
+- `eth_getFilterLogs`
+- `eth_getLogs`
+  - TODO: explain complexity
+- `eth_mining`
+- `eth_hashrate`
+- `eth_getWork`
+- `eth_submitWork`
+- `eth_submitHashrate`
+- `eth_sign`
+- `eth_signTransaction`
 
 [JSON-RPC Specs](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/portal-network-specs/assembled-spec/jsonrpc/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)
 
@@ -148,12 +196,12 @@ A [double batched merkle log accumulator](https://ethresear.ch/t/double-batched-
 - [Chain History Network](./history-network.md)
     - Prior work: https://notes.ethereum.org/oUJE4ZX2Q6eMOgEMiQPkpQ?view
     - Prior Python proof-of-concept: https://github.com/ethereum/ddht/tree/341e84e9163338556cd48dd2fcfda9eedec3eb45
-        - This POC shouldn't be considered representative of the end goal.  It incorperates mechanisms that aren't likely to be apart of the actual implementation, specifically the "advertisement" system which proved to be a big bottleneck, as well as the SSZ merkle root system which was a work-around for large data transfer which we now intend to solve with uTP.
+        - This POC should NOT be considered representative of the end goal.  It incorperates mechanisms that aren't likely to be apart of the actual implementation, specifically the "advertisement" system which proved to be a big bottleneck, as well as the SSZ merkle root system which was a work-around for large data transfer which we now intend to solve with uTP.
 - [Transaction Gossip Network](./transaction-gossip.md):
     - Spec is preliminary
     - Prior work: https://ethresear.ch/t/scalable-transaction-gossip/8660
 - [Header Gossip Network](./header-gossip-network.md)
-    - Spec if preliminary
-- Canonical Indices Network:
-    - No specification has been written.  Largely mirrors that of Chain History.
-
+    - Spec is preliminary
+- [Canonical Indices Network]A(./canonical-indices-network.md)
+    - Spec is preliminary.
+    - Network design borrows heavily from history network.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Portal Network is divided into the following sub-protocols.
 - Execution Header Gossip Network
 - Execution Canonical Indices Network
 
-Each of these sub-protocols is designed to deliver a specific unit of functionality.  Most portal clients will participate in all of these sub-protocols in order to deliver the full JSON-RPC API.  Each sub-protocols however is designed to be independent of the others, allowing clients the option of only participating in a subset of them if they wish.
+Each of these sub-protocols is designed to deliver a specific unit of functionality.  Most portal clients will participate in all of these sub-protocols in order to deliver the full JSON-RPC API.  Each sub-protocol however is designed to be independent of the others, allowing clients the option of only participating in a subset of them if they wish.
 
 All of the sub-protocols in the Portal Network establish their own overlay DHT that is managed independent of the base Discovery V5 DHT.
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ The Discovery v5 protocol allows building custom sub-protocols via the use of th
 
 The Portal Network is divided into the following sub-protocols.
 
-- State Network
-- History Network
+- Execution State Network
+- Execution History Network
 - Transaction Gossip Network
-- Header Gossip Network
-- Canonical Indices Network
+- Execution Header Gossip Network
+- Execution Canonical Indices Network
 
-Each of these networks is designed to deliver a specific unit of functionality.  Most portal clients will participate in all of these networks in order to deliver the full JSON-RPC API.  Each network however is designed to be independent of the others, allowing clients the option of only participating in a subset of them if they wish.
+Each of these sub-protocols is designed to deliver a specific unit of functionality.  Most portal clients will participate in all of these sub-protocols in order to deliver the full JSON-RPC API.  Each sub-protocols however is designed to be independent of the others, allowing clients the option of only participating in a subset of them if they wish.
 
-All of the sub-protocols in the Portal Network establish their own DHT network that is managed independent of the base Discovery V5 DHT.
+All of the sub-protocols in the Portal Network establish their own overlay DHT that is managed independent of the base Discovery V5 DHT.
 
 
 ## Terminology

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Each of these networks is designed to deliver a specific unit of functionality. 
 All of the sub-protocols in the Portal Network establish their own DHT network that is managed independent of the base Discovery V5 DHT.
 
 
+## Terminology
+
+The term "sub-protocol" is used to denote an individual protocol within the Portal Network.
+
+The term "network" is used contextually to refer to **either** the overall set of multiple protocols that comprise the Portal Network or an individual sub-protocol within the Portal Network.
+
+
+
 ## Design Principles
 
 Each of the Portal Network sub-protocols follows these design principles.

--- a/canonical-indices-network.md
+++ b/canonical-indices-network.md
@@ -95,7 +95,7 @@ A node is expected to maintain `radius` information for each node in its local n
 
 The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the canonical indices network.
 
-As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500B`.
+As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500E`.
 
 The canonical indices network supports the following protocol messages:
 - `Ping` - `Pong`

--- a/canonical-indices-network.md
+++ b/canonical-indices-network.md
@@ -1,0 +1,142 @@
+# Execution Canonical Indices Network
+
+This document is the specification for the sub-protocol that supports on-demand availability of the indices necessary for clients to lookup transactions by their hash and blocks by their number.
+
+## Overview
+
+The Execution canonical indices data consists of two data sets.
+
+- Mapping transaction hash to the canonical block hash and index of the transaction within the set of block transactions.
+- Mapping of block number to the canonical block hash for the block at that height.
+
+The canonical indices network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the canonical indices network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
+
+The `TALKREQ` and `TALKRESP` protocol messages are application-level messages whose contents are specific to the canonical indices network. We specify these messages below.
+
+The canonical indices network uses the node table structure from the Discovery v5 network and the lookup algorithm from section 2.3 of the Kademlia paper.
+
+### Data
+
+#### Types
+
+* Transaction Hash Lookup
+  * A mapping from transaction hash to canonical block hash and transaction index
+* Block Number Lookup
+  * A mapping from block number to canonical block hash
+
+
+## Specification
+
+### Distance
+
+Nodes in the canonical indices network are represented by their [EIP-778 Ethereum Node Record (ENR)](https://eips.ethereum.org/EIPS/eip-778) from the Discovery v5 network. A node's `node-id` is derived according to the node's identity scheme, which is specified in the node's ENR. A node's `node-id` represents its address in the DHT.
+
+The `node-id` is a 32-byte identifier. We define the `distance` function that maps a pair of `node-id` values to a 256-bit unsigned integer identically to the Discovery v5 network.
+
+```
+distance(n1, n2) = n1 XOR n2
+```
+
+Similarly, we define a `logdistance` function identically to the Discovery v5 network.
+
+```
+logdistance(n1, n2) = log2(distance(n1, n2))
+```
+
+### Content: Keys and Values
+
+The canonical indices DHT stores the following data items:
+
+* Transaction Hash to Block Hash and Transaction Index
+* Block Number to Block Hash
+
+Each of these data items are represented as a key-value pair. Denote the key for a data item by `content-key`. Denote the value for an item as `content`.
+
+All `content-key` values are encoded and decoded as an [`SSZ Union`](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#union) type.
+```
+content-key = Union[transaction_hash_lookup, block_number_lookup]
+serialized-content-key = serialize(content-key)
+```
+
+TODO: CONVERT FROM HERE ON DOWN
+
+#### Block Header
+
+```
+selector     = 0x00
+content-key  = Container(chain-id: uint16, block-hash: Bytes32)
+content       = rlp(header)
+```
+
+#### Block Body
+
+```
+selector     = 0x01
+content-key  = Container(chain-id: uint16, block-hash: Bytes32)
+content      = rlp([transaction_list, uncle_list])
+```
+
+#### Receipts
+
+```
+selector = 0x02
+content-key  = Container(chain-id: uint16, block-hash: Bytes32)
+content      = rlp(receipt_list)
+```
+
+#### Content ID
+
+We derive a `content-id` from the `content-key` as `H(serialized-content-key)` where `H` denotes the SHA-256 hash function, which outputs 32-byte values. The `content-id` represents the key in the DHT that we use for `distance` calculations.
+
+### Radius
+
+We define a `distance` function that maps a `node-id` and `content-id` pair to a 256-bit unsigned integer identically to the `distance` function for pairs of `node-id` values.
+
+Each node specifies a `radius` value, a 256-bit unsigned integer that represents the data that a node is "interested" in.
+
+```
+interested(node, content) = distance(node.id, content.id) <= node.radius
+```
+
+A node is expected to maintain `radius` information for each node in its local node table. A node's `radius` value may fluctuate as the contents of its local key-value store change.
+
+### Wire Protocol
+
+The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the history network.
+
+As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500B`.
+
+The history network supports the following protocol messages:
+- `Ping` - `Pong`
+- `Find Nodes` - `Nodes`
+- `Find Content` - `Found Content`
+- `Offer` - `Accept`
+
+In the history network the `custom_payload` field of the `Ping` and `Pong` messages is the serialization of an SSZ Container specified as `custom_data`:
+```
+custom_data = Container(data_radius: uint256)
+custom_payload = serialize(custom_data)
+```
+
+
+## Algorithms and Data Structures
+
+### Node State
+
+We adapt the node state from the Discovery v5 protocol. Assume identical definitions for the replication parameter `k` and a node's k-bucket table. Also assume that the routing table follows the structure and evolution described in section 2.4 of the Kademlia paper.
+
+Nodes keep information about other nodes in a routing table of k-buckets. This routing table is distinct from the node's underlying Discovery v5 routing table.
+
+A node associates the following tuple with each entry in its routing table:
+
+```
+node-entry := (node-id, radius, ip, udp)
+```
+
+The `radius` value is the only node information specific to the overlay protocol. This information is refreshed by the `Ping` and `Pong` protocol messages.
+
+A node should regularly refresh the information it keeps about its neighbors. We follow section 4.1 of the Kademlia paper to improve efficiency of these refreshes. A node delays `Ping` checks until it has a useful message to send to its neighbor.
+
+When a node discovers some previously unknown node, and the corresponding k-bucket is full, the newly discovered node is put into a replacement cache sorted by time last seen. If a node in the k-bucket fails a liveness check, and the replacement cache for that bucket is non-empty, then that node is replaced by the most recently seen node in the replacement cache.
+
+Consider a node in some k-bucket to be "stale" if it fails to respond to β messages in a row, where β is a system parameter. β may be a function of the number of previous successful liveness checks or of the age of the neighbor. If the k-bucket is not full, and the corresponding replacement cache is empty, then stale nodes should only be flagged and not removed. This ensures that a node who goes offline temporarily does not void its k-buckets.

--- a/canonical-indices-network.md
+++ b/canonical-indices-network.md
@@ -53,35 +53,26 @@ The canonical indices DHT stores the following data items:
 Each of these data items are represented as a key-value pair. Denote the key for a data item by `content-key`. Denote the value for an item as `content`.
 
 All `content-key` values are encoded and decoded as an [`SSZ Union`](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#union) type.
+
 ```
 content-key = Union[transaction_hash_lookup, block_number_lookup]
 serialized-content-key = serialize(content-key)
 ```
 
-TODO: CONVERT FROM HERE ON DOWN
-
-#### Block Header
+#### Transaction Hash Mapping
 
 ```
 selector     = 0x00
-content-key  = Container(chain-id: uint16, block-hash: Bytes32)
-content       = rlp(header)
+content-key  = Container(chain-id: uint16, transaction-hash: Bytes32)
+content       = TODO: block hash & merkle proof against header.transactions_trie
 ```
 
-#### Block Body
+#### Block Number Mapping
 
 ```
 selector     = 0x01
-content-key  = Container(chain-id: uint16, block-hash: Bytes32)
-content      = rlp([transaction_list, uncle_list])
-```
-
-#### Receipts
-
-```
-selector = 0x02
-content-key  = Container(chain-id: uint16, block-hash: Bytes32)
-content      = rlp(receipt_list)
+content-key  = Container(chain-id: uint16, block-number: uint256)
+content      = TODO: block hash & accumulator proof
 ```
 
 #### Content ID
@@ -102,17 +93,17 @@ A node is expected to maintain `radius` information for each node in its local n
 
 ### Wire Protocol
 
-The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the history network.
+The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the canonical indices network.
 
 As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500B`.
 
-The history network supports the following protocol messages:
+The canonical indices network supports the following protocol messages:
 - `Ping` - `Pong`
 - `Find Nodes` - `Nodes`
 - `Find Content` - `Found Content`
 - `Offer` - `Accept`
 
-In the history network the `custom_payload` field of the `Ping` and `Pong` messages is the serialization of an SSZ Container specified as `custom_data`:
+In the canonical indices network the `custom_payload` field of the `Ping` and `Pong` messages is the serialization of an SSZ Container specified as `custom_data`:
 ```
 custom_data = Container(data_radius: uint256)
 custom_payload = serialize(custom_data)

--- a/header-gossip-network.md
+++ b/header-gossip-network.md
@@ -1,10 +1,10 @@
-# Portal Network: Header Gossip
+# Execution Header Gossip Network
 
-This document is the specification for the "Header Gossip" network which is responsible for dissemination of new headers as new blocks are mined and  transmission of recent snapshots of the "Header Accumulator" data structure which all nodes on the network are expected to maintain.
+This document is the specification for the sub-protocol that facilitates transmission of new headers from the tip of the chain to all nodes in the network.  In addition, it facilitates acquisition of a snapshot of the "Header Accumulator" data structure.
 
 ## Design Requirements
 
-The network functionality has been designed around the following requirements.
+The header gossip network functionality has been designed around the following requirements.
 
 - A DHT node can reliably receive the headers for new blocks via the gossip mechanism in a timely manner.
 - A DHT node can retrieve a recent snapshot of another DHT node's "Header Accumulator"
@@ -77,11 +77,15 @@ Ignoring fluxuations in the size of `Accumulator.current_epoch` we should expect
 
 ## Wire Protocol
 
-The Header Gossip Network is an overlay network on the [Discovery V5 Protocol](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md).  The overlay network uses the PING/PONG/FINDNODES/FOUNDNODES/FINDCONTENT/FOUNDCONTENT/OFFER/ACCEPT messages from the [Portal Wire Protocol](./portal-wire-protocol.md).
+The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the transaction gossip network.
+
+As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500D`.
+
+The network uses the PING/PONG/FINDNODES/FOUNDNODES/FINDCONTENT/FOUNDCONTENT/OFFER/ACCEPT messages from the [Portal Wire Protocol](./portal-wire-protocol.md).
 
 ### Distance Function
 
-The Header Gossip Network uses the standard XOR distance function.
+The network uses the standard XOR distance function.
 
 ### PING payload
 
@@ -133,6 +137,7 @@ The gossip protocol for the header network is designed to quickly spread new hea
 Upon receiving a new block header via OFFER/ACCEPT a node should first check the validity of the header.
 
 Headers that pass the validity check should be propagated to `LOG2(num_entries_in_routing_table)` random nodes from the routing table via OFFER/ACCEPT.
+
 
 ## Accumulator Acquisition
 

--- a/history-network.md
+++ b/history-network.md
@@ -129,6 +129,7 @@ custom_data = Container(data_radius: uint256)
 custom_payload = serialize(custom_data)
 ```
 
+
 ## Algorithms and Data Structures
 
 ### Node State
@@ -150,4 +151,3 @@ A node should regularly refresh the information it keeps about its neighbors. We
 When a node discovers some previously unknown node, and the corresponding k-bucket is full, the newly discovered node is put into a replacement cache sorted by time last seen. If a node in the k-bucket fails a liveness check, and the replacement cache for that bucket is non-empty, then that node is replaced by the most recently seen node in the replacement cache.
 
 Consider a node in some k-bucket to be "stale" if it fails to respond to β messages in a row, where β is a system parameter. β may be a function of the number of previous successful liveness checks or of the age of the neighbor. If the k-bucket is not full, and the corresponding replacement cache is empty, then stale nodes should only be flagged and not removed. This ensures that a node who goes offline temporarily does not void its k-buckets.
-

--- a/history-network.md
+++ b/history-network.md
@@ -1,16 +1,16 @@
-# Execution History Network
+# Execution Chain History Sub-Network
 
-This document is the specification for the networking protocol that supports on-demand availability of Ethereum execution chain history data.
+This document is the specification for the sub-network that supports on-demand availability of Ethereum execution chain history data.
 
 ## Overview
 
 Execution chain history data consists of historical block headers, block bodies (transactions and ommer), and receipts.
 
-The chain history storage network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the history network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
+The chain history sub-network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the history network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
 
-The `TALKREQ` and `TALKRESP` protocol messages are application-level messages whose contents are specific to the history protocol. We specify these messages below.
+The `TALKREQ` and `TALKRESP` protocol messages are application-level messages whose contents are specific to the history sub-network. We specify these messages below.
 
-The history protocol uses the node table structure from the Discovery v5 network and the lookup algorithm from section 2.3 of the Kademlia paper.
+The history sub-network uses the node table structure from the Discovery v5 network and the lookup algorithm from section 2.3 of the Kademlia paper.
 
 ### Data
 
@@ -28,7 +28,7 @@ The history protocol uses the node table structure from the Discovery v5 network
 * Block body by block header hash
 * Block receipts by block header hash
 
-> This network does **not** support:
+> This subnetwork does **not** support:
 > 
 > - Header by block number
 > - Block by block number
@@ -41,7 +41,7 @@ The history protocol uses the node table structure from the Discovery v5 network
 
 ### Distance
 
-Nodes in the history network are represented by their [EIP-778 Ethereum Node Record (ENR)](https://eips.ethereum.org/EIPS/eip-778) from the Discovery v5 network. A node's `node-id` is derived according to the node's identity scheme, which is specified in the node's ENR. A node's `node-id` represents its address in the DHT.
+Nodes in the history subnetwork are represented by their [EIP-778 Ethereum Node Record (ENR)](https://eips.ethereum.org/EIPS/eip-778) from the Discovery v5 network. A node's `node-id` is derived according to the node's identity scheme, which is specified in the node's ENR. A node's `node-id` represents its address in the DHT.
 
 The `node-id` is a 32-byte identifier. We define the `distance` function that maps a pair of `node-id` values to a 256-bit unsigned integer identically to the Discovery v5 network.
 
@@ -113,7 +113,7 @@ A node is expected to maintain `radius` information for each node in its local n
 
 ### Wire Protocol
 
-The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the state network.
+The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the history sub-network.
 
 As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500B`.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -18,11 +18,11 @@ All protocol identifiers consist of two bytes. The first byte is "`P`" (`0x50`),
 
 Currently defined protocol identifiers:
 - Inclusive range of `0x5000` - `0x5009`: Reserved for future networks or network upgrades
-- `0x500A`: State Network
-- `0x500B`: History Network
+- `0x500A`: Execution State Network
+- `0x500B`: Execution History Network
 - `0x500C`: Transaction Gossip Network
-- `0x500D`: Header Gossip Network
-- `0x500E`: Canonical Indices Network
+- `0x500D`: Execution Header Gossip Network
+- `0x500E`: Execution Canonical Indices Network
 - `0x501A`: gossip channel: bc-light-client-snapshot
 - `0x501B`: gossip channel: bc-light-client-update
 - `0x501C`: DHT network: beacon-state
@@ -213,12 +213,14 @@ A collection of test vectors for this specification can be found in the
 
 ## Algorithms
 
-Here we define a collection of generic algorithms which can be applied to sub-networks implementing the wire protocol.
+Here we define a collection of generic algorithms which can be applied to sub-protocol implementing the wire protocol.
 
 
 ### Lookup
 
-We use the lookup algorithm described in section 2.3 of the Kademlia paper. A "node lookup" is the execution of the algorithm to find the `k` closest nodes to some `node-id`. A "content lookup" is the execution of the algorithm to find the data for `content-id` or the `k` closest nodes to `content-id`.
+We use the lookup algorithm described in section 2.3 of the Kademlia paper. 
+
+A "node lookup" is the execution of the algorithm to find the `k` closest nodes to some `node-id`. A "content lookup" is the execution of the algorithm to find the data for `content-id` or the `k` closest nodes to `content-id`.
 
 A `FindNode` request corresponds to a node lookup, and a `FindContent` request corresponds to a content lookup.
 
@@ -241,6 +243,8 @@ Following the join phase, a node's k-buckets are generally kept fresh by network
 To find a piece of content for `content-id`, a node performs a content lookup via `FindContent`. If the lookup succeeds, then the requestor sends an `Offer` message for the content to the closest node it observed that did not return the value and whose `radius` contains `content-id`.
 
 ### Storing Content
+
+The concept of content storage is only applicable to sub-protocols that implement persistant storage of data.
 
 To store a piece of content with DHT key `content-id`, a node performs a lookup to find the `k` closest nodes with radii that contain `content-id`. Then the node sends `Offer` messages to those nodes. For any node that responds to the `Offer` message with an `Accept` message, the local node attempts to transmit the content over the uTP connection with the `connection-id` from the `Accept` message.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -2,7 +2,7 @@
 
 The Portal wire protocol is the default p2p protocol by which Portal nodes communicate.
 
-The different protocol within the Portal network **MAY** use this protocol, but they **MUST** remain separated per network.
+The different sub-protocols within the Portal network **MAY** use this wire protocol, but they **MUST** remain separated per network.
 
 This is done at the [Node Discovery Protocol v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#talkreq-request-0x05) layer, by providing a different protocol byte string, per protocol, in the `TALKREQ` message.
 

--- a/state-network.md
+++ b/state-network.md
@@ -1,6 +1,6 @@
-# Execution State Sub-Protocol
+# Execution State Network
 
-This document is the specification for the subprotocol that supports on-demand availability of state data from the execution chain.
+This document is the specification for the sub-protocol that supports on-demand availability of state data from the execution chain.
 
 
 ## Overview
@@ -12,9 +12,9 @@ State data from the execution chain consists of:
 - The set of all contract bytecodes
 - Any information required to prove inclusion of the above data in the state.
 
-The subprotocol supports "on-demand" availability of the Ethereum execution state including proof of exclusion for non-existent data.
+The network supports "on-demand" availability of the Ethereum execution state including proof of exclusion for non-existent data.
 
-The execution state subprotocol is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the history network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
+The execution state network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the history network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
 
 ## DHT Network
 
@@ -34,7 +34,7 @@ We use the same PING/PONG/FINDNODES/NODES rules from base discovery v5 protocol 
 
 ### Content Keys and Content IDs
 
-The subprotocol supports the following schemes for addressing different types of content.
+The network supports the following schemes for addressing different types of content.
 
 All content keys are encoded as an [SSZ Union](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#union) type.
 

--- a/state-network.md
+++ b/state-network.md
@@ -1,30 +1,20 @@
-# Portal Network: State Network
+# Execution State Sub-Protocol
 
-This document is the specification for the "State" portion of the portal network.
+This document is the specification for the subprotocol that supports on-demand availability of state data from the execution chain.
 
-## Definition of "State"
 
-We define the Ethereum "State" to be the collection of:
+## Overview
+
+State data from the execution chain consists of:
 
 - The set of all accounts from the main account trie referenced by `Header.state_root`
 - The set of all contract storage values from all contracts
 - The set of all contract bytecodes
 - Any information required to prove inclusion of the above data in the state.
 
-## Overview
+The subprotocol supports "on-demand" availability of the Ethereum execution state including proof of exclusion for non-existent data.
 
-The network(s) that support "on-demand" availability of the Ethereum state must do the following things.
-
-- Retrieval:
-    - A: Mechanism for finding and retrieving recent "state" data.  This must also include proof of exclusion for non-existent data.
-- Storage:
-    - B: Mechanism for state data to be distributed to *interested* nodes in a provable manner.
-    
-    
-We solve A by mapping "state" data onto the Kademlia DHT such that nodes can determine the location in the network where a particular piece of state should be stored.  With a standard Kademlia DHT using the "recursive find" algorithm any node in the network can quickly find nodes that should be storing the data they are interested in.
-
-We solve B with a structured gossip algorithm that distributes the individual trie node data across the nodes in the DHT.  As the chain progresses, a witness of the new and updated state data will be generated at each new `Header.state_root`.  The individual trie nodes from this witness would then be distributed to the appropriate DHT nodes.
-
+The execution state subprotocol is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the history network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
 
 ## DHT Network
 
@@ -32,9 +22,9 @@ Our DHT will be an overlay network on the existing [Discovery V5](https://github
 
 Nodes **must** support the `utp` Discovery v5 sub-protocol to facilitate transmission of merkle proofs which will in most cases exceed the UDP packet size.
 
-We use a custom distance function defined below.
+We use the same routing table structure as the core protocol.
 
-We use the same routing table structure as the core protocol.  The routing table must use the custom distance function defined below.
+We use a custom distance function defined below.
 
 A separate instance of the routing table must be maintained for the state network, independent of the base routing table managed by the base discovery v5 protocol, only containing nodes that support the `portal-state` sub-protocol.  We refer to this as the *"overlay routing table"*.
 
@@ -44,7 +34,7 @@ We use the same PING/PONG/FINDNODES/NODES rules from base discovery v5 protocol 
 
 ### Content Keys and Content IDs
 
-The network supports the following schemes for addressing different types of content.
+The subprotocol supports the following schemes for addressing different types of content.
 
 All content keys are encoded as an [SSZ Union](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#union) type.
 

--- a/transaction-gossip.md
+++ b/transaction-gossip.md
@@ -1,11 +1,10 @@
-# Portal Network: Transaction Gossip
+# Transaction Gossip Network
 
 > NOTE: This specification is a work in progress.
 
-This document is the specification for the "Transaction Gossip" portion of the portal network.  The network is designed to enable participants to broadcast transactions which can be picked up by miners for inclusion in future blocks.
+This document is the specification for the sub-protocol that facilitates transmission of transactions from individual nodes in the network to block producers for inclusion in future blocks.
 
-
-## Design Requirements
+## Overview
 
 The transaction gossip network is designed with the following requirements.
 
@@ -16,11 +15,16 @@ The transaction gossip network is designed with the following requirements.
 
 ## Wire Protocol
 
-The Transaction Gossip Network uses the PING/PONG/FINDNODES/FOUNDNODES/OFFER/ACCEPT messages from the [Portal Wire Protocol](./portal-wire-protocol.md).
+The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the transaction gossip network.
+
+As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500C`.
+
+The network uses the PING/PONG/FINDNODES/FOUNDNODES/OFFER/ACCEPT messages from the [Portal Wire Protocol](./portal-wire-protocol.md).
+
 
 ### Distance Function
 
-The Transaction Gossip Network uses the standard XOR distance function.
+The network uses the standard XOR distance function.
 
 ### PING payload
 


### PR DESCRIPTION
Editorial review and update of most spec documents:

- Adds spec for canonical indices network
- Change to use the prefix "Execution" for networks that deal with the execution chain in preparation for future inclusion of Beacon chain networks.
- Define the terms "network" and "sub-protocol" and how they are used within the specs
- Add list of supported JSON-RPC endpoints
- Unification of language in how the different networks are described within their specifications.
- Move some common logic into common "Algorithms" section within the core portal wire protocol document
