### PR TITLE
Add varint prefix to offer/accept content items send over uTP stream

### DIFF
--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -206,10 +206,14 @@ Upon *sending* this message, the requesting node **SHOULD** *listen* for an inco
 
 Upon *receiving* this message, the serving node **SHOULD** *initiate* a uTP stream with the received `connection_id`.
 
-##### Content Encoding
-Up to 64 content items can be sent over the uTP stream after an `Offer` request and `Accept` response.
+#### Length Prefix Content Encoding
+Content data can be transfered over the uTP stream after the `Find Content` and `Content` request and response or after the `Offer` and `Accept` request and response. The length prefix content encoding MUST be applied on all content data send over the stream.
 
-In order to be able to discern these different content items, a variable length unsigned integer (varint) MUST be prefixed to each content item.
+Up to 64 content items can be sent over the stream after an `Offer` request and `Accept` response and the
+content encoding will allow to discern the different content items. Additionally, it MAY be used to close
+the stream early when all data is received.
+
+For length prefix content encoding, each content item that is to be send over the uTP stream MUST be prefixed with a variable length unsigned integer (varint).
 The varint MUST hold the size, in bytes, of the consecutive content item.
 
 The varint encoding used is [Unsigned LEB128](https://en.wikipedia.org/wiki/LEB128#Encode_unsigned_integer).

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -206,14 +206,10 @@ Upon *sending* this message, the requesting node **SHOULD** *listen* for an inco
 
 Upon *receiving* this message, the serving node **SHOULD** *initiate* a uTP stream with the received `connection_id`.
 
-#### Length Prefix Content Encoding
-Content data can be transfered over the uTP stream after the `Find Content` and `Content` request and response or after the `Offer` and `Accept` request and response. The length prefix content encoding MUST be applied on all content data send over the stream.
+##### Content Encoding
+Up to 64 content items can be sent over the uTP stream after an `Offer` request and `Accept` response.
 
-Up to 64 content items can be sent over the stream after an `Offer` request and `Accept` response and the
-content encoding will allow to discern the different content items. Additionally, it MAY be used to close
-the stream early when all data is received.
-
-For length prefix content encoding, each content item that is to be send over the uTP stream MUST be prefixed with a variable length unsigned integer (varint).
+In order to be able to discern these different content items, a variable length unsigned integer (varint) MUST be prefixed to each content item.
 The varint MUST hold the size, in bytes, of the consecutive content item.
 
 The varint encoding used is [Unsigned LEB128](https://en.wikipedia.org/wiki/LEB128#Encode_unsigned_integer).

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -206,6 +206,18 @@ Upon *sending* this message, the requesting node **SHOULD** *listen* for an inco
 
 Upon *receiving* this message, the serving node **SHOULD** *initiate* a uTP stream with the received `connection_id`.
 
+##### Content Encoding
+Up to 64 content items can be sent over the uTP stream after an `Offer` request and `Accept` response.
+
+In order to be able to discern these different content items, a variable length unsigned integer (varint) MUST be prefixed to each content item.
+The varint MUST hold the size, in bytes, of the consecutive content item.
+
+The varint encoding used is [Unsigned LEB128](https://en.wikipedia.org/wiki/LEB128#Encode_unsigned_integer).
+The maximum size allowed for this application is limited to `uint32`.
+
+The content item itself MUST be encoded as is defined for each specific network and content type.
+
+
 ### Test Vectors
 
 A collection of test vectors for this specification can be found in the

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -217,6 +217,14 @@ The maximum size allowed for this application is limited to `uint32`.
 
 The content item itself MUST be encoded as is defined for each specific network and content type.
 
+The encoded data of n encoded content items to be send over the stream can be formalized as:
+```py
+# n encoded content items to be send over the stream, with n <= 64
+encoded_content_list = [content_0, content_1, ..., content_n]
+
+# encoded data to be send over the stream
+encoded_data = varint(len(content_0)) + content_0 + varint(len(content_1)) + content_1 + ... + varint(len(content_n)) + content_n
+```
 
 ### Test Vectors
 


### PR DESCRIPTION
Added a section on prefixing a varint to each content item as possible solution to be able to send multiple content items over the uTP stream after offer/accept request-response. This should be able to preserve the streaming capabilities versus e.g. an SSZ List.

I've specified it only for the offer/accept request response, as that is the only location where multiple items can be send over the uTP stream. But if preferred to be used over the whole line, it could also be applied for FindContent/Content (in which case I would move the section). 

