### PR TITLE
Define length of max historical epochs in header gossip spec

### DIFF
--- a/header-gossip-network.md
+++ b/header-gossip-network.md
@@ -18,7 +18,7 @@ The accumulator is defined as an [SSZ](https://ssz.dev/) data structure with the
 
 ```python
 EPOCH_SIZE = 8192 # blocks
-MAX_HISTORICAL_EPOCHS = XXXX
+MAX_HISTORICAL_EPOCHS = 100000
 
 # An individual record for a historical header.
 HeaderRecord = Container[block_hash: bytes32, total_difficulty: uint256]

--- a/header-gossip-network.md
+++ b/header-gossip-network.md
@@ -18,7 +18,7 @@ The accumulator is defined as an [SSZ](https://ssz.dev/) data structure with the
 
 ```python
 EPOCH_SIZE = 8192 # blocks
-MAX_HISTORICAL_EPOCHS = 100000
+MAX_HISTORICAL_EPOCHS = 131072  # 2**17
 
 # An individual record for a historical header.
 HeaderRecord = Container[block_hash: bytes32, total_difficulty: uint256]


### PR DESCRIPTION
It's important to define an actual limit for the max historical epochs we want to support in the header accumulator as different implementations selecting a different value will lead to accumulators having different hash tree roots (as discovered by Ultralight/Fluffy when trying to harmonize test outputs in #145).  There's nothing magical about 100,000 other than it was selected by the two teams as a starting point and 100,000 historical epochs would get us to 819,200,000 million blocks (still more than 50x the length of the current mainnet chain) and have a size of roughly 3MB.