### PR TITLE
Move accumulator to from header gossip to history network

### DIFF
--- a/content-keys-test-vectors.md
+++ b/content-keys-test-vectors.md
@@ -99,7 +99,7 @@ content_id: U256 = 9243655320250466575533858917172702581481192615849913473767356
 
 ### History Network Keys
 
-#### HeaderKey
+#### Block Header Key
 
 ##### Input Parameters
 ```
@@ -114,7 +114,7 @@ content_id = 0x2137f185b713a60dd1190e650d01227b4f94ecddc9c95478e2c591c40557da99
 content_id: U256 = 15025167517633317571792618561170587584740338038067807801482118109695980329625
 ```
 
-#### BodyKey
+#### Block Body Key
 
 ##### Input Parameters
 ```
@@ -129,7 +129,7 @@ content_id = 0x1c6046475f0772132774ab549173ca8487bea031ce539cad8e990c08df5802ca
 content_id: U256 = 12834862124958403129911294156243112356210437741210740000860318140844473844426
 ```
 
-#### ReceiptsKey
+#### Receipt Key
 
 ##### Input Parameters
 ```
@@ -144,3 +144,46 @@ content_id = 0xaa39e1423e92f5a667ace5b79c2c98adbfd79c055d891d0b9c49c40f816563b2
 content_id: U256 = 76995449220721979583200368506411933662679656077191192504502358532083948020658
 ```
 
+#### Epoch Accumulator Key
+
+##### Input Parameters
+```
+epoch_hash = 0xe242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491
+```
+
+##### Expected Output
+```
+content_key = 0x03e242814b90ed3950e13aac7e56ce116540c71b41d1516605aada26c6c07cc491
+content_id = 0x9fb2175e76c6989e0fdac3ee10c40d2a81eb176af32e1c16193e3904fe56896e
+content_id: U256 = 72232402989179419196382321898161638871438419016077939952896528930608027961710
+```
+
+#### Master Accumulator Key - Latest
+
+##### Input Parameters
+```
+None # Select latest
+```
+
+##### Expected Output
+```
+content_key = 0x0400
+# Note: content id is probably rather pointless in this case
+content_id = 0xc0ba8a33ac67f44abff5984dfbb6f56c46b880ac2b86e1f23e7fa9c402c53ae7
+content_id: U256 = 87173654316145541646904042090629917349369185510102051783618763191692466404071
+```
+
+#### Master Accumulator Key - Hash
+
+##### Input Parameters
+```
+master_hash = 0x88cce8439ebc0c1d007177ffb6831c15c07b4361984cc52235b6fd728434f0c7
+```
+
+##### Expected Output
+```
+content_key = 0x040188cce8439ebc0c1d007177ffb6831c15c07b4361984cc52235b6fd728434f0c7
+# Note: content id is probably rather pointless in this case
+content_id = 0xaf75c3c9d0e89a5083361a3334a9c5583955f0dbe9a413eb79ba26400d1824a6
+content_id: U256 = 79362820890138237094338894474079140563693945795365426184460738681339857347750
+```

--- a/header-gossip-network.md
+++ b/header-gossip-network.md
@@ -1,79 +1,12 @@
 # Execution Header Gossip Network
 
-This document is the specification for the sub-protocol that facilitates transmission of new headers from the tip of the chain to all nodes in the network.  In addition, it facilitates acquisition of a snapshot of the "Header Accumulator" data structure.
+This document is the specification for the sub-protocol that facilitates transmission of new headers from the tip of the chain to all nodes in the network.
 
 ## Design Requirements
 
 The header gossip network functionality has been designed around the following requirements.
 
 - A DHT node can reliably receive the headers for new blocks via the gossip mechanism in a timely manner.
-- A DHT node can retrieve a recent snapshot of another DHT node's "Header Accumulator"
-
-
-## The "Header Accumulator"
-
-The "Header Accumulator" is based on the [double-batched merkle log accumulator](https://ethresear.ch/t/double-batched-merkle-log-accumulator/571) that is currently used in the beacon chain.  This data structure is designed to allow nodes in the network to "forget" the deeper history of the chain, while still being able to reliably receive historical headers with a proof that the received header is indeed from the canonical chain (as opposed to an uncle mined at the same block height).
-
-The accumulator is defined as an [SSZ](https://ssz.dev/) data structure with the following schema:
-
-```python
-EPOCH_SIZE = 8192 # blocks
-MAX_HISTORICAL_EPOCHS = 131072  # 2**17
-
-# An individual record for a historical header.
-HeaderRecord = Container[block_hash: bytes32, total_difficulty: uint256]
-
-# The records of the headers from within a single epoch
-EpochAccumulator = List[HeaderRecord, max_length=EPOCH_SIZE]
-
-Accumulator = Container[
-    historical_epochs: List[bytes32, max_length=MAX_HISTORICAL_EPOCHS],
-    current_epoch: EpochAccumulator,
-]
-```
-
-The algorithm for managing the accumulator is as follows.
-
-> TODO: provide a written spec too
-
-```python
-def update_accumulator(accumulator: Accumulator, new_block_header: BlockHeader) -> None:
-    # get the previous total difficulty
-    if len(accumulator.current_epoch) == 0:
-        # genesis
-        last_total_difficulty = 0
-    else:
-        last_total_difficulty = accumulator.current_epoch[-1].total_difficulty
-
-    # check if the epoch accumulator is full.
-    if len(accumulator.current_epoch) == EPOCH_SIZE:
-        # compute the final hash for this epoch
-        epoch_hash = hash_tree_root(accumulator.current_epoch)
-        # append the hash for this epoch to the list of historical epochs
-        accumulator.historical_epochs.append(epoch_hash)
-        # initialize a new empy epoch
-        accumulator.current_epoch = []
-
-    # construct the concise record for the new header and add it to the current epoch.
-    header_record = HeaderRecord(header.hash, last_total_difficulty + header.difficulty)
-    accumulator.current_epoch.append(header_record)
-```
-
-### Growth over time
-
-Each `HeaderRecord` is 64 bytes meaning the `EpochAccumulator` can range from `0 - 64 * EPOCH_SIZE` bytes (0-512KB) over the course of a single epoch.
-
-The `Accumulator.historical_epochs` grows by 32 bytes per epoch.
-
-At a 13 second block time we expect:
-
-- ~1 epochs per day
-- ~6 epochs per week
-- ~25 epochs per month
-- ~296 epochs per year
-
-Ignoring fluxuations in the size of `Accumulator.current_epoch` we should expect the size of the accumulator to grow at a rate of roughly 10kb per year.
-
 
 ## Wire Protocol
 
@@ -89,42 +22,26 @@ The network uses the standard XOR distance function.
 
 ### PING payload
 
-TODO: specify what a node should do prior to having acquired a copy of the accumulator
-
 ```
 Ping.custom_payload := ssz_serialize(custom_data)
-custom_data         := Container(accumulator_root_hash: Bytes32, fork_id: Bytes32, head_hash: Bytes32, head_td: uint256)
+custom_data         := Container(fork_id: Bytes32, head_hash: Bytes32, head_td: uint256)
 ```
 
 ### PONG payload
 
-TODO: specify what a node should do prior to having acquired a copy of the accumulator
-
 ```
 Pong.custom_payload := ssz_serialize(custom_data)
-custom_data         := Container(accumulator_root_hash: Bytes32, fork_id: Bytes32, head_hash: Bytes32, head_td: uint256)
+custom_data         := Container(fork_id: Bytes32, head_hash: Bytes32, head_td: uint256)
 ```
 
 ## Content Keys
-
-### Accumulator Snapshot
-
-> Note: The `content-id` for this content key is not used for any purpose.
-
-```
-content_key  := Container(content_type: uint8, accumulator_root_hash: Bytes32)
-content_type := 0x01
-content_id   := accumulator_root_hash
-```
-
-TODO: wire serialization for FINDCONTENT/FOUNDCONTENT
 
 ### New Block Header
 
 
 ```
 content_key  := Container(content_type: uint8, block_hash: Bytes32, block_number: uint256)
-content_type := 0x02
+content_type := 0x00
 content_id   := block_hash
 ```
 
@@ -137,12 +54,3 @@ The gossip protocol for the header network is designed to quickly spread new hea
 Upon receiving a new block header via OFFER/ACCEPT a node should first check the validity of the header.
 
 Headers that pass the validity check should be propagated to `LOG2(num_entries_in_routing_table)` random nodes from the routing table via OFFER/ACCEPT.
-
-
-## Accumulator Acquisition
-
-New nodes entering the network will need to acquire an up-to-date snapshot of the accumulator.
-
-The Header Gossip Network does provide the ability to acquire a snapshot of another node's accumulator. Since the accumulator is not a part of the base protocol (and thus is not part of the block header), nodes will have to do their own due diligence to either build the full accumulator from genesis or to adequately verify and validate a snapshot acquired from another peer.
-
-TODO: provide basic probabilistic approach for verification of an accumulator snapshot.

--- a/history-network.md
+++ b/history-network.md
@@ -5,6 +5,7 @@ This document is the specification for the sub-protocol that supports on-demand 
 ## Overview
 
 Execution chain history data consists of historical block headers, block bodies (transactions and ommer), and receipts.
+In addition, it facilitates acquisition of a snapshot of the "Header Accumulator" data structure.
 
 The chain history network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that forms an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) network. The term *overlay network* means that the history network operates with its own independent routing table and uses the extensible `TALKREQ` and `TALKRESP` messages from the base Discovery v5 protocol for communication.
 
@@ -21,13 +22,20 @@ The history network uses the node table structure from the Discovery v5 network 
     * Transactions
     * Omners
 * Receipts
+* Header epoch accumulators
+* Header master accumulator
 
 #### Retrieval
 
 * Block header by block header hash
 * Block body by block header hash
 * Block receipts by block header hash
+* Header epoch accumulator by epoch accumulator hash
+* Header master accumulator by master accumulator hash or by requesting latest
 
+
+<!-- TODO: we can actually provide header by block number or block by block
+number by requesting the right epoch accumulator, so this could be adjusted -->
 > This sub-protocol does **not** support:
 >
 > - Header by block number
@@ -55,6 +63,70 @@ Similarly, we define a `logdistance` function identically to the Discovery v5 ne
 logdistance(n1, n2) = log2(distance(n1, n2))
 ```
 
+### The "Header Accumulator"
+
+The "Header Accumulator" is based on the [double-batched merkle log accumulator](https://ethresear.ch/t/double-batched-merkle-log-accumulator/571) that is currently used in the beacon chain.  This data structure is designed to allow nodes in the network to "forget" the deeper history of the chain, while still being able to reliably receive historical headers with a proof that the received header is indeed from the canonical chain (as opposed to an uncle mined at the same block height).
+
+The accumulator is defined as an [SSZ](https://ssz.dev/) data structure with the following schema:
+
+```python
+EPOCH_SIZE = 8192 # blocks
+MAX_HISTORICAL_EPOCHS = 131072  # 2**17
+
+# An individual record for a historical header.
+HeaderRecord = Container[block_hash: bytes32, total_difficulty: uint256]
+
+# The records of the headers from within a single epoch
+EpochAccumulator = List[HeaderRecord, max_length=EPOCH_SIZE]
+
+MasterAccumulator = Container[
+    historical_epochs: List[bytes32, max_length=MAX_HISTORICAL_EPOCHS],
+    current_epoch: EpochAccumulator,
+]
+```
+
+The algorithm for managing the accumulator is as follows.
+
+> TODO: provide a written spec too
+
+```python
+def update_accumulator(accumulator: MasterAccumulator, new_block_header: BlockHeader) -> None:
+    # get the previous total difficulty
+    if len(accumulator.current_epoch) == 0:
+        # genesis
+        last_total_difficulty = 0
+    else:
+        last_total_difficulty = accumulator.current_epoch[-1].total_difficulty
+
+    # check if the epoch accumulator is full.
+    if len(accumulator.current_epoch) == EPOCH_SIZE:
+        # compute the final hash for this epoch
+        epoch_hash = hash_tree_root(accumulator.current_epoch)
+        # append the hash for this epoch to the list of historical epochs
+        accumulator.historical_epochs.append(epoch_hash)
+        # initialize a new empy epoch
+        accumulator.current_epoch = []
+
+    # construct the concise record for the new header and add it to the current epoch.
+    header_record = HeaderRecord(header.hash, last_total_difficulty + header.difficulty)
+    accumulator.current_epoch.append(header_record)
+```
+
+#### Growth over time
+
+Each `HeaderRecord` is 64 bytes meaning the `EpochAccumulator` can range from `0 - 64 * EPOCH_SIZE` bytes (0-512KB) over the course of a single epoch.
+
+The `Accumulator.historical_epochs` grows by 32 bytes per epoch.
+
+At a 13 second block time we expect:
+
+- ~1 epochs per day
+- ~6 epochs per week
+- ~25 epochs per month
+- ~296 epochs per year
+
+Ignoring fluxuations in the size of `Accumulator.current_epoch` we should expect the size of the accumulator to grow at a rate of roughly 10kb per year.
+
 ### Content: Keys and Values
 
 The chain history DHT stores the following data items:
@@ -62,13 +134,15 @@ The chain history DHT stores the following data items:
 * Block headers
 * Block bodies
 * Receipts
+* Header epoch accumulators
+* Header master accumulator
 
 Each of these data items are represented as a key-value pair. Denote the key for a data item by `content-key`. Denote the value for an item as `content`.
 
-All `content-key` values are encoded and decoded as an [`SSZ Union`](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#union) type.
+All `content_key` values are encoded and decoded as an [`SSZ Union`](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#union) type.
 ```
-content-key = Union[blockheader, blockbody, receipt]
-serialized-content-key = serialize(content-key)
+content_key = Union[block_header_key, block_body_key, receipt_key, epoch_accumulator_key, master_accumulator_key]
+serialized_content_key = SSZ.serialize(content_key)
 ```
 
 #### Constants
@@ -108,26 +182,31 @@ MAX_ENCODED_UNCLES_LENGTH = _MAX_HEADER_LENGTH * 2**4  # = 2**17 ~= 131k
 #### Block Header
 
 ```
-selector     = 0x00
-content-key  = Container(chain-id: uint16, block-hash: Bytes32)
-content      = rlp(header)
+block_header_key = Container(chain_id: uint16, block_hash: Bytes32)
+selector = 0x00
+
+content = rlp.encode(header)
 ```
 
 #### Block Body
 
 ```
+block_body_key = Container(chain_id: uint16, block_hash: Bytes32)
 selector                = 0x01
-content-key             = Container(chain-id: uint16, block-hash: Bytes32)
-content                 = Container(all-transactions, ssz-uncles)
-all-transactions        = SSZList(ssz-transaction, max-length=MAX_TRANSACTION_COUNT)
-ssz-transaction         = SSZList(encoded-transaction: Byte, max-length=MAX_TRANSACTION_LENGTH)
-encoded-transaction     =
+
+content                 = Container(all_transactions, ssz_uncles)
+all_transactions        = SSZList(ssz_transaction, max_length=MAX_TRANSACTION_COUNT)
+ssz_transaction         = SSZList(encoded_transaction: Byte, max_length=MAX_TRANSACTION_LENGTH)
+encoded_transaction     =
   if transaction.is_typed:
     return type_byte + rlp.encode(transaction)
   else:
     return rlp.encode(transaction)
-ssz-uncles              = SSZList(encoded-uncles: Byte, max-length=MAX_ENCODED_UNCLES_LENGTH)
-encoded-uncles          = rlp.encode(list-of-uncle-headers)
+ssz_uncles              = SSZList(encoded_uncles: Byte, max_length=MAX_ENCODED_UNCLES_LENGTH)
+encoded_uncles          = rlp.encode(list_of_uncle_headers)
+
+
+content = rlp([transaction_list, uncle_list])
 ```
 
 Note the type-specific encoding might be different in future transaction types, but this encoding
@@ -136,16 +215,40 @@ works for all current transaction types.
 #### Receipts
 
 ```
-selector            = 0x02
-content-key         = Container(chain-id: uint16, block-hash: Bytes32)
-content             = SSZList(ssz-receipt, max-length=MAX_TRANSACTION_COUNT)
-ssz-receipt         = SSZList(encoded-receipt: Byte, max-length=MAX_RECEIPT_LENGTH)
-encoded-receipt     =
+receipt_key = Container(chain_id: uint16, block_hash: Bytes32)
+selector = 0x02
+
+content             = SSZList(ssz_receipt, max_length=MAX_TRANSACTION_COUNT)
+ssz_receipt         = SSZList(encoded_receipt: Byte, max_length=MAX_RECEIPT_LENGTH)
+encoded_receipt     =
   if receipt.is_typed:
     return type_byte + rlp.encode(receipt)
   else:
     return rlp.encode(receipt)
 ```
+
+#### Epoch Accumulator
+
+```
+epoch_accumulator_key = Container(epoch_hash: Bytes32)
+selector = 0x03
+epoch_hash = hash_tree_root(epoch_accumulator)
+
+content = SSZ.serialize(epoch_accumulator)
+```
+
+#### Master Accumulator
+
+```
+master_accumulator_key = Union[None, master_hash: Bytes32]
+selector = 0x04
+master_hash = hash_tree_root(master_accumulator)
+
+content = SSZ.serialize(master_accumulator)
+```
+
+> A `None` in the content key is equivalent to the request of the latest
+master accumulator that the requested node has available.
 
 Note the type-specific encoding might be different in future receipt types, but this encoding works
 for all current receipt types.
@@ -165,6 +268,9 @@ each receipt/transaction and re-rlp-encode it, but only if it is a legacy transa
 #### Content ID
 
 We derive a `content-id` from the `content-key` as `H(serialized-content-key)` where `H` denotes the SHA-256 hash function, which outputs 32-byte values. The `content-id` represents the key in the DHT that we use for `distance` calculations.
+
+<!-- TODO: the content-id of the accumulators could probably be directly
+the hash_tree_root value, to avoid another hashing operation? -->
 
 ### Radius
 
@@ -196,6 +302,10 @@ custom_data = Container(data_radius: uint256)
 custom_payload = serialize(custom_data)
 ```
 
+<!-- TODO: Add the accumulator root hash as custom data to the ping/pong
+payloads as was done in the header gossip network? Lets figure this out when
+also figuring out how to kick off with a accumulator snapshot. -->
+
 
 ## Algorithms and Data Structures
 
@@ -218,3 +328,12 @@ A node should regularly refresh the information it keeps about its neighbors. We
 When a node discovers some previously unknown node, and the corresponding k-bucket is full, the newly discovered node is put into a replacement cache sorted by time last seen. If a node in the k-bucket fails a liveness check, and the replacement cache for that bucket is non-empty, then that node is replaced by the most recently seen node in the replacement cache.
 
 Consider a node in some k-bucket to be "stale" if it fails to respond to β messages in a row, where β is a system parameter. β may be a function of the number of previous successful liveness checks or of the age of the neighbor. If the k-bucket is not full, and the corresponding replacement cache is empty, then stale nodes should only be flagged and not removed. This ensures that a node who goes offline temporarily does not void its k-buckets.
+
+
+### Accumulator Acquisition
+
+New nodes entering the network will need to acquire an up-to-date snapshot of the accumulator.
+
+The Header Gossip Network does provide the ability to acquire a snapshot of another node's accumulator. Since the accumulator is not a part of the base protocol (and thus is not part of the block header), nodes will have to do their own due diligence to either build the full accumulator from genesis or to adequately verify and validate a snapshot acquired from another peer.
+
+TODO: provide basic probabilistic approach for verification of an accumulator snapshot.

--- a/history-network.md
+++ b/history-network.md
@@ -104,11 +104,11 @@ def update_accumulator(accumulator: MasterAccumulator, new_block_header: BlockHe
         epoch_hash = hash_tree_root(accumulator.current_epoch)
         # append the hash for this epoch to the list of historical epochs
         accumulator.historical_epochs.append(epoch_hash)
-        # initialize a new empy epoch
+        # initialize a new empty epoch
         accumulator.current_epoch = []
 
     # construct the concise record for the new header and add it to the current epoch.
-    header_record = HeaderRecord(header.hash, last_total_difficulty + header.difficulty)
+    header_record = HeaderRecord(new_block_header.hash, last_total_difficulty + new_block_header.difficulty)
     accumulator.current_epoch.append(header_record)
 ```
 
@@ -183,15 +183,15 @@ MAX_ENCODED_UNCLES_LENGTH = _MAX_HEADER_LENGTH * 2**4  # = 2**17 ~= 131k
 
 ```
 block_header_key = Container(chain_id: uint16, block_hash: Bytes32)
-selector = 0x00
+selector         = 0x00
 
-content = rlp.encode(header)
+content          = rlp.encode(header)
 ```
 
 #### Block Body
 
 ```
-block_body_key = Container(chain_id: uint16, block_hash: Bytes32)
+block_body_key          = Container(chain_id: uint16, block_hash: Bytes32)
 selector                = 0x01
 
 content                 = Container(all_transactions, ssz_uncles)
@@ -204,9 +204,6 @@ encoded_transaction     =
     return rlp.encode(transaction)
 ssz_uncles              = SSZList(encoded_uncles: Byte, max_length=MAX_ENCODED_UNCLES_LENGTH)
 encoded_uncles          = rlp.encode(list_of_uncle_headers)
-
-
-content = rlp([transaction_list, uncle_list])
 ```
 
 Note the type-specific encoding might be different in future transaction types, but this encoding
@@ -215,8 +212,8 @@ works for all current transaction types.
 #### Receipts
 
 ```
-receipt_key = Container(chain_id: uint16, block_hash: Bytes32)
-selector = 0x02
+receipt_key         = Container(chain_id: uint16, block_hash: Bytes32)
+selector            = 0x02
 
 content             = SSZList(ssz_receipt, max_length=MAX_TRANSACTION_COUNT)
 ssz_receipt         = SSZList(encoded_receipt: Byte, max_length=MAX_RECEIPT_LENGTH)
@@ -231,20 +228,20 @@ encoded_receipt     =
 
 ```
 epoch_accumulator_key = Container(epoch_hash: Bytes32)
-selector = 0x03
-epoch_hash = hash_tree_root(epoch_accumulator)
+selector              = 0x03
+epoch_hash            = hash_tree_root(epoch_accumulator)
 
-content = SSZ.serialize(epoch_accumulator)
+content               = SSZ.serialize(epoch_accumulator)
 ```
 
 #### Master Accumulator
 
 ```
 master_accumulator_key = Union[None, master_hash: Bytes32]
-selector = 0x04
-master_hash = hash_tree_root(master_accumulator)
+selector               = 0x04
+master_hash            = hash_tree_root(master_accumulator)
 
-content = SSZ.serialize(master_accumulator)
+content                = SSZ.serialize(master_accumulator)
 ```
 
 > A `None` in the content key is equivalent to the request of the latest


### PR DESCRIPTION
- Move accumulator to the history network
- Add definitions for content keys of master and epoch accumulator
- Add Serialization for accumulator content
- Add test vectors for accumulator content keys

This moves the accumulator definition from header gossip to the history network and adds the content keys as defined in https://github.com/ethereum/portal-network-specs/issues/153:
- One difference is that the content key for the master accumulator is directly a `Union` type.

Not sure what to do with `chain_id` at this point? Get rid of it everywhere or use it everywhere? For now I did neither and left it untouched :)

The history spec could probably use some reorganization after this and some text is redundant, but that is not the scope of this PR. Scope right now is defining accumulator keys & content serialization and adding test vectors so that we can easily make the clients compatible. This is the current implemented state of Fluffy, but we can obviously adjust.
