### PR TITLE
portal_historyOffer: send to interested peers

### DIFF
--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -117,9 +117,9 @@
       "$ref": "#/components/schemas/bytes8"
     }
   },
-  "StoreContent": {
-    "name": "contentData",
-    "description": "Content data to store",
+  "ContentValue": {
+    "name": "contentValue",
+    "description": "The encoded Content value",
     "required": true,
     "schema": {
       "$ref": "#/components/schemas/hexString"

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -99,20 +99,10 @@
   },
   "OfferResult": {
     "name": "offerResult",
-    "description": "Returns ACCEPT message",
+    "description": "Returns the number of peers that the content was gossiped to",
     "schema": {
-      "title": "ACCEPT message",
-      "type": "object",
-      "properties": {
-        "connectionId": {
-          "description": "Connection ID to set up a uTP stream to transmit the requested data",
-          "$ref": "#/components/schemas/bytes2"
-        },
-        "contentKeys": {
-          "description": "Signals which content keys are desired",
-          "$ref": "#/components/schemas/hexString"
-        }
-      }
+      "title": "number of peers",
+      "type": "number"
     }
   },
    "SendOfferResult": {

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -287,13 +287,13 @@
   },
   {
     "name": "portal_historyOffer",
-    "summary": "Request message to offer a set of content_keys that this node has content available for.",
+    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
-        "$ref": "#/components/contentDescriptors/Enr"
+        "$ref": "#/components/contentDescriptors/ContentKey"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
+        "$ref": "#/components/contentDescriptors/ContentValue"
       }
     ],
     "result": {
@@ -323,7 +323,7 @@
         "$ref": "#/components/contentDescriptors/ContentKey"
       },
       {
-        "$ref": "#/components/contentDescriptors/StoreContent"
+        "$ref": "#/components/contentDescriptors/ContentValue"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -323,7 +323,7 @@
         "$ref": "#/components/contentDescriptors/ContentKey"
       },
       {
-        "$ref": "#/components/contentDescriptors/StoreContent"
+        "$ref": "#/components/contentDescriptors/ContentValue"
       }
     ],
     "result": {


### PR DESCRIPTION
This is a useful API for bridge nodes, to push content out to peers of a running portal client.

It seems that most clients have not built out both APIs and started using them (`portal_historyOffer` and `portal_historySendOffer`), so I am proposing that we repurpose `portal_historyOffer` for broad gossiping, and use `portal_historySendOffer` for testing out specific messages.