### PR TITLE
jsonrpc: Add portal_*LocalContent` endpoint to JSON-RPC specs

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -225,5 +225,18 @@
     "schema": {
       "type": "boolean"
     }
+  },
+  "LocalContentResult": {
+    "name": "localContentResult",
+    "description": "Returns a hex content value. If content is not available, returns \"0x0\"",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "contentValue": {
+          "description": "Hex encoded content value",
+          "$ref": "#/components/schemas/hexString"
+        }
+      }
+    }
   }
 }

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -152,6 +152,18 @@
     }
   },
   {
+    "name": "portal_historyLocalContent",
+    "summary": "Get a content from the local database",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/LocalContentResult"
+    }
+  },
+  {
     "name": "portal_historyPing",
     "summary": "Send a PING message to the designated node and wait for a PONG response.",
     "params": [

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -152,6 +152,18 @@
     }
   },
   {
+    "name": "portal_stateLocalContent",
+    "summary": "Get a content from the local database",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/LocalContentResult"
+    }
+  },
+  {
     "name": "portal_statePing",
     "summary": "Send a PING message to the designated node and wait for a PONG response.",
     "params": [


### PR DESCRIPTION
Adding the `portal_*LocalContent` endpoint to JSON-RPC specs. This endpoint is useful for interop testing to check if a client stored content in the local database.