### PR TITLE
JSON-RPC rename offer to gossip and add new offer call

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -99,9 +99,10 @@
   },
   "OfferResult": {
     "name": "offerResult",
-    "description": "Returns \"true\" upon success",
+    "description": "Returns the content keys bitlist upon successful content transmission or empty bitlist receival",
     "schema": {
-      "type": "boolean"
+      "title": "Encoded content keys bitlist",
+      "$ref": "#/components/schemas/hexString"
     }
   },
    "SendOfferResult": {

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -99,10 +99,9 @@
   },
   "OfferResult": {
     "name": "offerResult",
-    "description": "Returns the number of peers that the content was gossiped to",
+    "description": "Returns \"true\" upon success",
     "schema": {
-      "title": "number of peers",
-      "type": "number"
+      "type": "boolean"
     }
   },
    "SendOfferResult": {
@@ -237,6 +236,14 @@
           "$ref": "#/components/schemas/hexString"
         }
       }
+    }
+  },
+  "GossipResult": {
+    "name": "gossipResult",
+    "description": "Returns the number of peers that the content was gossiped to",
+    "schema": {
+      "title": "number of peers",
+      "type": "number"
     }
   }
 }

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -240,8 +240,11 @@
   },
   {
     "name": "portal_historyOffer",
-    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
     "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       },
@@ -301,8 +304,22 @@
       }
     ],
     "result": {
-
       "$ref": "#/components/contentDescriptors/LocalContentResult"
+    }
+  },
+  {
+    "name": "portal_historyGossip",
+    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentValue"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/GossipResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -240,13 +240,16 @@
   },
   {
     "name": "portal_stateOffer",
-    "summary": "Request message to offer a set of content_keys that this node has content available for.",
+    "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentValue"
       }
     ],
     "result": {
@@ -301,8 +304,22 @@
       }
     ],
     "result": {
-
       "$ref": "#/components/contentDescriptors/LocalContentResult"
+    }
+  },
+  {
+    "name": "portal_stateGossip",
+    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentValue"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/GossipResult"
     }
   }
 ]


### PR DESCRIPTION
The `portal_historyOffer` call had been altered to basically do neighborhoud gossip.

To make that clear, lets call it instead `portal_historyGossip` and make a `portal_historyOffer` call that only offers content to a specifically provided node.