### PR TITLE
Reorder JSON RPC calls and delete duplicates

### DIFF
--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -1,37 +1,10 @@
-[ {
-    "name": "portal_historyAccept",
-    "summary": "Signals interest in receiving the offered data from the corresponding Offer message.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/AcceptResult"
-    }
-  },
+[
   {
-    "name": "portal_historySendAccept",
-    "summary": "Signals interest in receiving the offered data from the corresponding Offer message.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
-      }
-    ],
+    "name": "portal_historyRoutingTableInfo",
+    "summary": "Returns meta information about history network routing table.",
+    "params": [],
     "result": {
-      "$ref": "#/components/contentDescriptors/SendAcceptResult"
+      "$ref": "#/components/contentDescriptors/RoutingTableInfoResult"
     }
   },
   {
@@ -152,15 +125,72 @@
     }
   },
   {
-    "name": "portal_historyLocalContent",
-    "summary": "Get a content from the local database",
+    "name": "portal_historySendFindContent",
+    "summary": "Send FINDCONTENT message.",
     "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/LocalContentResult"
+      "$ref": "#/components/contentDescriptors/SendFindContentResult"
+    }
+  },
+  {
+    "name": "portal_historySendContent",
+    "summary": "Send CONTENT message. This message can contain either a uTP connection ID, a list of ENRs or the requested content.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ConnectionId"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/Content"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/Enrs"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/SendContentResult"
+    }
+  },
+  {
+    "name": "portal_historySendOffer",
+    "summary": "Request message to offer a set of content_keys that this node has content available for.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentKeys"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/SendOfferResult"
+    }
+  },
+  {
+    "name": "portal_historySendAccept",
+    "summary": "Signals interest in receiving the offered data from the corresponding Offer message.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ConnectionId"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentKeys"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/SendAcceptResult"
     }
   },
   {
@@ -194,26 +224,6 @@
     }
   },
   {
-    "name": "portal_historyRecursiveFindNodes",
-    "summary": "Lookup a target node within in the network",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/NodeId"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindNodeResult"
-    }
-  },
-  {
-    "name": "portal_historyRoutingTableInfo",
-    "summary": "Returns meta information about history network routing table.",
-    "params": [],
-    "result": {
-      "$ref": "#/components/contentDescriptors/RoutingTableInfoResult"
-    }
-  },
-  {
     "name": "portal_historyFindContent",
     "summary": "Send FINDCONTENT message to get the content with a content key.",
     "params": [
@@ -226,75 +236,6 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/FindContentResult"
-    }
-  },
-  {
-    "name": "portal_historyRecursiveFindContent",
-    "summary": "Look up a target content key in the network",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
-    }
-  },
-  {
-    "name": "portal_historySendFindContent",
-    "summary": "Send FINDCONTENT message.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/SendFindContentResult"
-    }
-  },
-  {
-    "name": "portal_historyContent",
-    "summary": "Send CONTENT message. This message can contain either a uTP connection ID, a list of ENRs or the requested content.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Content"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Enrs"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
-    }
-  },
-  {
-    "name": "portal_historySendContent",
-    "summary": "Send CONTENT message. This message can contain either a uTP connection ID, a list of ENRs or the requested content.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Content"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Enrs"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/SendContentResult"
     }
   },
   {
@@ -313,18 +254,27 @@
     }
   },
   {
-    "name": "portal_historySendOffer",
-    "summary": "Request message to offer a set of content_keys that this node has content available for.",
+    "name": "portal_historyRecursiveFindNodes",
+    "summary": "Lookup a target node within in the network",
     "params": [
       {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
+        "$ref": "#/components/contentDescriptors/NodeId"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/SendOfferResult"
+      "$ref": "#/components/contentDescriptors/RecursiveFindNodeResult"
+    }
+  },
+  {
+    "name": "portal_historyRecursiveFindContent",
+    "summary": "Look up a target content key in the network",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
     }
   },
   {
@@ -340,6 +290,19 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/ContentResult"
+    }
+  },
+  {
+    "name": "portal_historyLocalContent",
+    "summary": "Get a content from the local database",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+
+      "$ref": "#/components/contentDescriptors/LocalContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -1,37 +1,10 @@
-[ {
-    "name": "portal_stateAccept",
-    "summary": "Signals interest in receiving the offered data from the corresponding Offer message.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/AcceptResult"
-    }
-  },
+[
   {
-    "name": "portal_stateSendAccept",
-    "summary": "Signals interest in receiving the offered data from the corresponding Offer message.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
-      }
-    ],
+    "name": "portal_stateRoutingTableInfo",
+    "summary": "Returns meta information about state network routing table.",
+    "params": [],
     "result": {
-      "$ref": "#/components/contentDescriptors/SendAcceptResult"
+      "$ref": "#/components/contentDescriptors/RoutingTableInfoResult"
     }
   },
   {
@@ -152,15 +125,72 @@
     }
   },
   {
-    "name": "portal_stateLocalContent",
-    "summary": "Get a content from the local database",
+    "name": "portal_stateSendFindContent",
+    "summary": "Send FINDCONTENT message..",
     "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/LocalContentResult"
+      "$ref": "#/components/contentDescriptors/SendFindContentResult"
+    }
+  },
+  {
+    "name": "portal_stateSendContent",
+    "summary": "Send CONTENT message. This message can contain either a uTP connection ID, a list of ENRs or the requested content.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ConnectionId"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/Content"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/Enrs"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/SendContentResult"
+    }
+  },
+  {
+    "name": "portal_stateSendOffer",
+    "summary": "Request message to offer a set of content_keys that this node has content available for.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentKeys"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/SendOfferResult"
+    }
+  },
+  {
+    "name": "portal_stateSendAccept",
+    "summary": "Signals interest in receiving the offered data from the corresponding Offer message.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Enr"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ConnectionId"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentKeys"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/SendAcceptResult"
     }
   },
   {
@@ -194,26 +224,6 @@
     }
   },
   {
-    "name": "portal_stateRecursiveFindNodes",
-    "summary": "Lookup a target node within in the network",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/NodeId"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindNodeResult"
-    }
-  },
-  {
-    "name": "portal_stateRoutingTableInfo",
-    "summary": "Returns meta information about state network routing table.",
-    "params": [],
-    "result": {
-      "$ref": "#/components/contentDescriptors/RoutingTableInfoResult"
-    }
-  },
-  {
     "name": "portal_stateFindContent",
     "summary": "Send FINDCONTENT message to get the content with a content key.",
     "params": [
@@ -226,75 +236,6 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/FindContentResult"
-    }
-  },
-  {
-    "name": "portal_stateRecursiveFindContent",
-    "summary": "Look up a target content key in the network",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
-    }
-  },
-  {
-    "name": "portal_stateSendFindContent",
-    "summary": "Send FINDCONTENT message..",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/SendFindContentResult"
-    }
-  },
-  {
-    "name": "portal_stateContent",
-    "summary": "Send CONTENT message. This message can contain either a uTP connection ID, a list of ENRs or the requested content.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Content"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Enrs"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
-    }
-  },
-  {
-    "name": "portal_stateSendContent",
-    "summary": "Send CONTENT message. This message can contain either a uTP connection ID, a list of ENRs or the requested content.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ConnectionId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Content"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/Enrs"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/SendContentResult"
     }
   },
   {
@@ -313,18 +254,27 @@
     }
   },
   {
-    "name": "portal_stateSendOffer",
-    "summary": "Request message to offer a set of content_keys that this node has content available for.",
+    "name": "portal_stateRecursiveFindNodes",
+    "summary": "Lookup a target node within in the network",
     "params": [
       {
-        "$ref": "#/components/contentDescriptors/Enr"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentKeys"
+        "$ref": "#/components/contentDescriptors/NodeId"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/SendOfferResult"
+      "$ref": "#/components/contentDescriptors/RecursiveFindNodeResult"
+    }
+  },
+  {
+    "name": "portal_stateRecursiveFindContent",
+    "summary": "Look up a target content key in the network",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
     }
   },
   {
@@ -340,6 +290,19 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/ContentResult"
+    }
+  },
+  {
+    "name": "portal_stateLocalContent",
+    "summary": "Get a content from the local database",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+
+      "$ref": "#/components/contentDescriptors/LocalContentResult"
     }
   }
 ]


### PR DESCRIPTION
Reorder the JSON RPC calls to make it more intuitive to find them.
- Order more consistently for discv5, history and state
- Order related calls close to each other
- Delete some duplicate calls: portal_*Accept and portal_*Content


I found it sometimes difficult to figure out which call I'm looking at / looking for. Hopefully this improves it a bit.

Aside from that, I'd be fine with removing all the `Send` versions of the calls. Fluffy does not support them as they are difficult to implement and would require quite some refactor. I don't see a good use case for them either. If other clients have the same view on this, it would make the spec also smaller / easier.