### PR TITLE
State Network revisions

### DIFF
--- a/state-network.md
+++ b/state-network.md
@@ -155,7 +155,7 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
 selector               := 0x01
 
-content                := Container(witnesses: MPTWitness)
+content                := Container(witness: MPTWitness)
 content_id             := (keccak(address) + keccak(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -131,7 +131,7 @@ A node should track their own radius value and provide this value in all Ping or
 Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.  We specify 1024 as the maximum length due to constraints in the SSZ spec for list lengths being a power of 2 (for easier merkleization.)
 ```
 WitnessNode            := ByteList(1024)
-MPTWitness          := List(witnesses: WitnessNode, max_length=32)
+MPTWitness             := List(witnesses: WitnessNode, max_length=32)
 ```
 
 #### Account Trie Proof

--- a/state-network.md
+++ b/state-network.md
@@ -155,7 +155,7 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
 selector               := 0x01
 
-content                := Container(witnesses: mpt_witnesses)
+content                := Container(witnesses: MPTWitness)
 content_id             := (keccak(address) + keccak(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -142,7 +142,7 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
-content                := Container(witnesses: mpt_witnesses, nonce: uint64, balance: uint256, code_hash: Bytes32, storage_root: Bytes32)
+content                := Container(witnesses: mpt_witnesses)
 content_id             := keccak(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```
@@ -155,7 +155,7 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
 selector               := 0x01
 
-content                := Container(witnesses: mpt_witnesses, slot_value: Bytes32)
+content                := Container(witnesses: mpt_witnesses)
 content_id             := (keccak(address) + keccak(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -128,9 +128,9 @@ A node should track their own radius value and provide this value in all Ping or
 #### Component Data Elements
 
 #### Proofs
-Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.
+Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.  We specify 1024 as the maximum length due to constraints in the SSZ spec for list lengths being a power of 2 (for easier merkleization.)
 ```
-mpt_witness_node       := ByteList(667)
+mpt_witness_node       := ByteList(1024)
 mpt_witnesses          := List(witnesses: mpt_witness_node[], max_length=32)
 ```
 
@@ -155,7 +155,7 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
 selector               := 0x01
 
-content                := Container(witnesses: mpt_witnesses, data: Bytes32)
+content                := Container(witnesses: mpt_witnesses, slot_value: Bytes32)
 content_id             := (keccak(address) + keccak(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -131,7 +131,7 @@ A node should track their own radius value and provide this value in all Ping or
 Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.  We specify 1024 as the maximum length due to constraints in the SSZ spec for list lengths being a power of 2 (for easier merkleization.)
 ```
 WitnessNode            := ByteList(1024)
-MPTWitness             := List(witnesses: WitnessNode, max_length=32)
+MPTWitness             := List(witness: WitnessNode, max_length=32)
 ```
 
 #### Account Trie Proof

--- a/state-network.md
+++ b/state-network.md
@@ -142,7 +142,7 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
-content                := Container(witnesses: mpt_witnesses)
+content                := Container(witnesses: MPTWitness)
 content_id             := keccak(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -125,6 +125,15 @@ A node should track their own radius value and provide this value in all Ping or
 
 ### Data Types
 
+#### Component Data Elements
+
+#### Proofs
+Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.
+```
+mpt_witness_node       := ByteList(667)
+mpt_witnesses          := List(witnesses: mpt_witness_node[], 17)
+```
+
 #### Account Trie Proof
 
 A leaf node from the main account trie and accompanying merkle proof against a recent `Header.state_root`
@@ -133,7 +142,8 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
-content_id             := keccak(address)
+content                := Container(witnesses: mpt_witnesses, nonce: Uint64, balance: Uint256, code_hash: Bytes32, storage_root: Bytes32)
+content_id             := sha256(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```
 
@@ -145,7 +155,8 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
 selector               := 0x01
 
-content_id             := (keccak(address) + keccak(slot)) % 2**256
+content                := Container(witnesses: mpt_witnesses, data: Bytes32)
+content_id             := (sha256(address) + sha256(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```
 
@@ -157,7 +168,8 @@ The bytecode for a specific contract as referenced by `Account.code_hash`
 contract_bytecode_key := Container(address: Bytes20, code_hash: Bytes32)
 selector              := 0x02
 
-content_id            := sha256(address | code_hash)
+content               := ByteList(24756)  // Represents maximum possible size of contract bytecode
+content_id            := sha256(address + code_hash)
 content_key           := selector + SSZ.serialize(contract_bytecode_key)
 ```
 

--- a/state-network.md
+++ b/state-network.md
@@ -131,7 +131,7 @@ A node should track their own radius value and provide this value in all Ping or
 Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.
 ```
 mpt_witness_node       := ByteList(667)
-mpt_witnesses          := List(witnesses: mpt_witness_node[], 17)
+mpt_witnesses          := List(witnesses: mpt_witness_node[], max_length=32)
 ```
 
 #### Account Trie Proof

--- a/state-network.md
+++ b/state-network.md
@@ -143,7 +143,7 @@ account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
 content                := Container(witnesses: mpt_witnesses, nonce: Uint64, balance: Uint256, code_hash: Bytes32, storage_root: Bytes32)
-content_id             := sha256(address)
+content_id             := keccak(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```
 
@@ -156,7 +156,7 @@ storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root:
 selector               := 0x01
 
 content                := Container(witnesses: mpt_witnesses, data: Bytes32)
-content_id             := (sha256(address) + sha256(slot)) % 2**256
+content_id             := (keccak(address) + keccak(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```
 

--- a/state-network.md
+++ b/state-network.md
@@ -142,7 +142,7 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
-content                := Container(witnesses: mpt_witnesses, nonce: Uint64, balance: Uint256, code_hash: Bytes32, storage_root: Bytes32)
+content                := Container(witnesses: mpt_witnesses, nonce: uint64, balance: uint256, code_hash: Bytes32, storage_root: Bytes32)
 content_id             := keccak(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -130,8 +130,8 @@ A node should track their own radius value and provide this value in all Ping or
 #### Proofs
 Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.  We specify 1024 as the maximum length due to constraints in the SSZ spec for list lengths being a power of 2 (for easier merkleization.)
 ```
-mpt_witness_node       := ByteList(1024)
-mpt_witnesses          := List(witnesses: mpt_witness_node[], max_length=32)
+WitnessNode            := ByteList(1024)
+MPTWitness          := List(witnesses: WitnessNode, max_length=32)
 ```
 
 #### Account Trie Proof

--- a/state-network.md
+++ b/state-network.md
@@ -142,7 +142,7 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
-content                := Container(witnesses: MPTWitness)
+content                := Container(witness: MPTWitness)
 content_id             := keccak(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```


### PR DESCRIPTION
This updates the state spec in the following ways:
- Switches bitwise OR in Contract Bytecode `content_id` to byte concatenation for consistency with rest of `content_id` derivations (open to discussion on this but not obvious to me why we're using bitwise OR here - seems like it could lead to hash collision since there are plenty of possible `address`/`code_hash` that would produce the same input to the hash
- Adds proposed types for the content of each content type
