### PR TITLE
add trie node data

### DIFF
--- a/state-network.md
+++ b/state-network.md
@@ -142,7 +142,8 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
 selector               := 0x00
 
-content                := Container(witness: MPTWitness)
+leaf_node              := Container(nonce: uint64, balance: uint256, codeHash: Bytes32, storageRoot: Bytes32)
+content                := Container(witness: MPTWitness, account: leaf_node)
 content_id             := keccak(address)
 content_key            := selector + SSZ.serialize(account_trie_proof_key)
 ```

--- a/state-network.md
+++ b/state-network.md
@@ -156,7 +156,7 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
 selector               := 0x01
 
-content                := Container(witness: MPTWitness)
+content                := Container(witness: MPTWitness, leaf: Bytes32)
 content_id             := (keccak(address) + keccak(slot)) % 2**256
 content_key            := selector + SSZ.serialize(storage_trie_proof_key)
 ```


### PR DESCRIPTION
The state_network trie proof content types currently only contain the witness lists, and not the actual leaf data:

https://github.com/ethereum/portal-network-specs/blob/3a8b529939bf6c6f727c1e1cb4a79e46f1c8d05e/state-network.md?plain=1#L137-L148

This PR defines SSZ types for `account trie` leaf data, and cotract `storage trie` leaf data, and includes them in the content container types.


for `account trie proof`:
defines an ssz container for the trie leaf data and adds a field to the content container:

```
leaf_node              := Container(nonce: uint64, balance: uint256, codeHash: Bytes32, storageRoot: Bytes32)
content                := Container(witness: MPTWitness, account: leaf_node)
```
and for `contract storage trie proof`: 
adds field to content container for leaf data
```
content                := Container(witness: MPTWitness, leaf: Bytes32)
```