### PR TITLE
Adjust JSON-RPC spec to return 0x when no content is found

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -6,8 +6,8 @@
       "type": "boolean"
     }
   },
-  "ContentResult": {
-    "name": "contentResult",
+  "StoreResult": {
+    "name": "storeResult",
     "description": "Returns \"true\" upon success",
     "schema": {
       "type": "boolean"
@@ -113,14 +113,6 @@
       }
     }
   },
-  "RecursiveFindContentResult": {
-    "name": "recursiveFindContentResult",
-    "description": "The data corresponding to the lookup target",
-    "schema": {
-      "title": "Encoded target content data",
-      "$ref": "#/components/schemas/hexString"
-    }
-  },
   "RoutingTableInfoResult": {
     "name": "routingTableInfoResult",
     "description": "history network routing table information",
@@ -147,9 +139,9 @@
       }
     }
   },
-  "LocalContentResult": {
-    "name": "localContentResult",
-    "description": "Returns a hex content value. If content is not available, returns \"0x0\"",
+  "ContentResult": {
+    "name": "ContentResult",
+    "description": "Returns the hex encoded content value. If the content is not available, returns \"0x\"",
     "schema": {
       "type": "object",
       "properties": {

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -142,7 +142,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/ContentResult"
     }
   },
   {
@@ -157,7 +157,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
+      "$ref": "#/components/contentDescriptors/StoreResult"
     }
   },
   {
@@ -169,7 +169,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/LocalContentResult"
+      "$ref": "#/components/contentDescriptors/ContentResult"
     }
   },
   {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -142,7 +142,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/ContentResult"
     }
   },
   {
@@ -157,7 +157,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
+      "$ref": "#/components/contentDescriptors/StoreResult"
     }
   },
   {
@@ -169,7 +169,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/LocalContentResult"
+      "$ref": "#/components/contentDescriptors/ContentResult"
     }
   },
   {


### PR DESCRIPTION
The 0x for no content found is applicable for RecursiveFindContent and LocalContent calls. Make use of one ContentResult type for both these calls in the definition.

The use of `0x` instead 0f `0x0` is more in line with the existing execution layer JSON-RPC API, where `0x` is used for unformatted data (https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding).