### PR TITLE
Clarify getEnr and lookupEnr JSON-RPC and remote seqNum parameter

### DIFF
--- a/jsonrpc/src/methods/discv5.json
+++ b/jsonrpc/src/methods/discv5.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "discv5_getEnr",
-    "summary": "Fetch the latest ENR associated with the given node ID",
+    "summary": "Fetch from the local node the latest ENR associated with the given NodeId",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/NodeId"
@@ -123,13 +123,10 @@
   },
   {
     "name": "discv5_lookupEnr",
-    "summary": "Fetch the ENR representation associated with the given Node ID and optional sequence number",
+    "summary": "Fetch from the DHT the latest ENR associated with the given NodeId",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/NodeId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/EnrSeq"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "portal_historyGetEnr",
-    "summary": "Fetch the latest ENR associated with the given node ID",
+    "summary": "Fetch from the local node the latest ENR associated with the given NodeId",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/NodeId"
@@ -45,13 +45,10 @@
   },
   {
     "name": "portal_historyLookupEnr",
-    "summary": "Fetch the ENR representation associated with the given Node ID and optional sequence number",
+    "summary": "Fetch from the DHT the latest ENR associated with the given NodeId",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/NodeId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/EnrSeq"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "portal_stateGetEnr",
-    "summary": "Fetch the latest ENR associated with the given node ID",
+    "summary": "Fetch from the local node the latest ENR associated with the given NodeId",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/NodeId"
@@ -45,13 +45,10 @@
   },
   {
     "name": "portal_stateLookupEnr",
-    "summary": "Fetch the ENR representation associated with the given Node ID and optional sequence number",
+    "summary": "Fetch from the DHT the latest ENR associated with the given NodeId",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/NodeId"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/EnrSeq"
       }
     ],
     "result": {


### PR DESCRIPTION
The description of getENR and lookupEnr was not very different. Attempted to clarify that. I didn't write implementation details on how the fetching of the network needs to happen, as I'm not sure we want to do that, and if we do, perhaps a more general location for that would be better.

As is not clear how the seqNum parameter is to be used and how it is useful in the lookupEnr call, I've removed it.


