### PR TITLE
JSON-RPC types cleanup

### DIFF
--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -8,15 +8,33 @@
   },
   "ContentKey": {
     "name": "contentKey",
+    "description": "The encoded Portal content key",
     "required": true,
     "schema": {
       "$ref": "#/components/schemas/hexString"
     }
   },
-   "Discv5Payload": {
-    "name": "payload",
+  "ContentValue": {
+    "name": "contentValue",
+    "description": "The encoded Portal content value",
     "required": true,
-    "description": "request element of message-data",
+    "schema": {
+      "$ref": "#/components/schemas/hexString"
+    }
+  },
+  "ProtocolId": {
+    "name": "protocolId",
+    "required": true,
+    "description": "The protocol element of discv5 TALKREQ message-data",
+    "schema": {
+      "title": "protocol id",
+      "$ref": "#/components/schemas/hexString"
+    }
+  },
+   "TalkReqPayload": {
+    "name": "talkReqPayload",
+    "required": true,
+    "description": "The request element of discv5 TALKREQ message-data",
     "schema": {
       "$ref": "#/components/schemas/hexString"
     }
@@ -43,6 +61,7 @@
   "EnrSeq": {
     "name": "enrSeq",
     "schema": {
+      "title": "The ENR sequence number",
       "type": "number"
     }
   },
@@ -59,23 +78,6 @@
     "description": "Data radius value",
     "schema": {
       "$ref": "#/components/schemas/DataRadius"
-    }
-  },
-   "ProtocolId": {
-    "name": "protocolId",
-    "required": true,
-    "description": "protocol element of message-data",
-    "schema": {
-      "title": "protocol id",
-      "$ref": "#/components/schemas/hexString"
-    }
-  },
-  "ContentValue": {
-    "name": "contentValue",
-    "description": "The encoded Content value",
-    "required": true,
-    "schema": {
-      "$ref": "#/components/schemas/hexString"
     }
   }
 }

--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -6,28 +6,11 @@
       "type": "number"
     }
   },
-  "Content": {
-    "name": "content",
-    "description": "Content data",
-    "schema": {
-      "$ref": "#/components/schemas/hexString"
-    }
-  },
   "ContentKey": {
     "name": "contentKey",
     "required": true,
     "schema": {
       "$ref": "#/components/schemas/hexString"
-    }
-  },
-  "ContentKeys": {
-    "name": "contentKeys",
-    "description": "A list of encoded content_key entries",
-    "schema": {
-      "type": "array",
-      "items": {
-        "$ref": "#/components/schemas/hexString"
-      }
     }
   },
    "Discv5Payload": {
@@ -57,16 +40,6 @@
       "$ref": "#/components/schemas/Enr"
     }
   },
-  "Enrs": {
-    "name": "enrs",
-    "description": "List of ENR records of nodes.",
-    "schema": {
-      "type": "array",
-      "items": {
-        "$ref": "#/components/schemas/Enr"
-      }
-    }
-  },
   "EnrSeq": {
     "name": "enrSeq",
     "schema": {
@@ -79,17 +52,6 @@
     "schema": {
       "title": "NodeId",
       "$ref": "#/components/schemas/bytes32"
-    }
-  },
-  "Nodes": {
-    "name": "nodes",
-    "required": true,
-    "schema": {
-      "title": "nodes",
-      "type": "array",
-      "items": {
-        "$ref": "#/components/schemas/Enr"
-      }
     }
   },
   "DataRadius": {
@@ -106,15 +68,6 @@
     "schema": {
       "title": "protocol id",
       "$ref": "#/components/schemas/hexString"
-    }
-  },
-  "RequestId": {
-    "name": "requestId",
-    "description": "request-id element of message-data",
-    "required": true,
-    "schema": {
-      "title": "Hex encoded RLP byte array of length <= 8 bytes",
-      "$ref": "#/components/schemas/bytes8"
     }
   },
   "ContentValue": {

--- a/jsonrpc/src/methods/discv5.json
+++ b/jsonrpc/src/methods/discv5.json
@@ -195,7 +195,7 @@
         "$ref": "#/components/contentDescriptors/ProtocolId"
       },
       {
-        "$ref": "#/components/contentDescriptors/Discv5Payload"
+        "$ref": "#/components/contentDescriptors/TalkReqPayload"
       }
     ],
     "result": {

--- a/jsonrpc/src/schemas/base_types.json
+++ b/jsonrpc/src/schemas/base_types.json
@@ -24,11 +24,6 @@
     "type": "string",
     "pattern": "^0x[0-9a-f]{64}$"
   },
-  "bytes33": {
-    "title": "33 hex encoded bytes",
-    "type": "string",
-    "pattern": "^0x[0-9a-f]{66}$"
-  },
   "hexString": {
     "title": "Hex string",
     "type": "string",

--- a/jsonrpc/src/schemas/portal.json
+++ b/jsonrpc/src/schemas/portal.json
@@ -1,10 +1,18 @@
 {
-  "Bucket": {
-    "title": "Bucket info",
+  "kBucket": {
+    "title": "kBucket info",
     "description": "List of up to 16 hex encoded nodeIds, ordered from least-recently connected to most-recently connected.",
     "type": "array",
     "items": {
       "$ref": "#/components/schemas/bytes32"
+    }
+  },
+  "kBuckets": {
+    "title": "kBuckets",
+    "description": "The buckets comprising the routing table.",
+    "type": "array",
+    "items": {
+      "$ref": "#/components/schemas/kBucket"
     }
   },
   "DataRadius": {
@@ -20,14 +28,6 @@
     "title": "IP v4/v6 address",
     "type": "string",
     "pattern": "((^\\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\\s*$)|(^\\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:)))(%.+)?\\s*$))"
-  },
-  "kBuckets": {
-    "title": "kBuckets",
-    "description": "The buckets comprising the routing table.",
-    "type": "array",
-    "items": {
-      "$ref": "#/components/schemas/Bucket"
-    }
   },
   "socketAddr": {
     "title": "ENR socket address",


### PR DESCRIPTION
A bit of clean-up: there were several unused leftover types (probably from previous API endpoint removals) and some naming/description improvements.