### PR TITLE
Adjust the FindContent JSON-RPC call to also retrieve data over uTP

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -45,9 +45,14 @@
         {
           "title": "ENRs",
           "description": "List of ENR records of nodes that are closer than the recipient is to the requested content",
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/Enr"
+          "type": "object",
+          "properties": {
+            "enrs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Enr"
+              }
+            }
           }
         }
       ]

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -30,6 +30,10 @@
         {
           "title": "ContentInfo",
           "type": "object",
+          "required": [
+            "content",
+            "utpTransfer"
+          ],
           "properties": {
             "content": {
               "title": "Requested content",
@@ -46,6 +50,7 @@
           "title": "ENRs",
           "description": "List of ENR records of nodes that are closer than the recipient is to the requested content",
           "type": "object",
+          "required": ["enrs"],
           "properties": {
             "enrs": {
               "type": "array",

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -21,28 +21,36 @@
     }
   },
   "FindContentResult": {
-    "name": "findContentResult",
-    "description": "Returns CONTENT message with a content or, in case the recipient does not have the data, a list of ENR records of nodes that are closer than the recipient is to the requested content.",
+    "name": "FindContentResult",
+    "description": "Returns either the requested content, received directly from the CONTENT message or transferred over uTP, or, in case the recipient does not have the content, a list of ENR records of nodes that are closer than the recipient is to the requested content.",
     "schema": {
-      "title": "CONTENT message",
+      "title": "FindContentResult",
       "type": "object",
-      "properties": {
-        "connectionId": {
-          "description": "uTP connection ID",
-          "$ref": "#/components/schemas/bytes2"
+      "oneOf" :[
+        {
+          "title": "ContentInfo",
+          "type": "object",
+          "properties": {
+            "content": {
+              "title": "Requested content",
+              "description": "Encoded requested content",
+              "$ref": "#/components/schemas/hexString"
+            },
+            "utpTransfer": {
+              "description": "Indicates whether the content was transferred over a uTP connection or not.",
+              "type": "boolean"
+            }
+          }
         },
-        "content": {
-          "description": "Requested content",
-          "$ref": "#/components/schemas/hexString"
-        },
-        "enrs": {
-          "description": "list of ENR records of nodes that are closer than the recipient is to the requested content",
+        {
+          "title": "ENRs",
+          "description": "List of ENR records of nodes that are closer than the recipient is to the requested content",
           "type": "array",
           "items": {
             "$ref": "#/components/schemas/Enr"
           }
         }
-      }
+      ]
     }
   },
   "FindNodeResult": {


### PR DESCRIPTION
Currently it was implied, due to the ConnectionId result, that the returned values are these of the CONTENT protocol call and that the uTP transfer was not done all or not awaited for. It is however more interesting to have a call that also does the data transfer over uTP.

Here the call gets adjusted to do the transfer over uTP, but the result still allows for returning ENRs when the data is not available, and to indicate whether a uTP transfer was used or not.

Looks like this in openrpc playground:

edit: new picture of how it looks after the additions of https://github.com/ethereum/portal-network-specs/pull/206/commits/1a462d57479feab46b4362dab04ea8d7a85e2186 and https://github.com/ethereum/portal-network-specs/pull/206/commits/e120d3a285c281cd4ee10e5a2d4774590fe6cfa2

![image](https://user-images.githubusercontent.com/7857583/234693027-68bb73d5-ecf0-45c4-848b-230895bedae5.png)
