### PR TITLE
Adjust discv5_updateNodeInfo JSON-RPC according to its summary

### DIFF
--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -72,5 +72,27 @@
     "schema": {
       "$ref": "#/components/schemas/DataRadius"
     }
+  },
+  "EnrKeyValuePairs": {
+    "name": "EnrKeyValuePairs",
+    "description": "Key-value pairs for an ENR.",
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/hexString"
+          },
+          "value": {
+            "$ref": "#/components/schemas/hexString"
+          }
+        }
+      }
+    }
   }
 }

--- a/jsonrpc/src/methods/discv5.json
+++ b/jsonrpc/src/methods/discv5.json
@@ -32,22 +32,10 @@
   },
   {
     "name": "discv5_updateNodeInfo",
-    "summary": "Add, update, or remove a key-value pair from the local node record",
+    "summary": "Add, update, or remove a key-value pairs from the local node ENR. Attempt to update the id or secp256k1 key must result in failure.",
     "params": [
       {
-        "name": "socketAddr",
-        "required": true,
-        "schema": {
-          "title": "ENR socket address",
-          "$ref": "#/components/schemas/socketAddr"
-        }
-      },
-      {
-        "name": "isTcp",
-        "description": "TCP or UDP socket",
-        "schema": {
-          "type": "boolean"
-        }
+        "$ref": "#/components/contentDescriptors/EnrKeyValuePairs"
       }
     ],
     "result": {


### PR DESCRIPTION
The existing summary was stating that it can add, update, or remove a key-value pair from the local ENR. However, the specification only allows for the socket address.
This change allows to touch any key/value except for those with keys id and secp256k1.

This is more aligned with how to call is specified here: https://ddht.readthedocs.io/en/latest/jsonrpc.html#discv5-updatenodeinfo

The schema basically allows something like this:
```json
[
  {
    "key": "0xabcd",
    "value": "0xffff"
  },
  {
    "key": "0xffff",
    "value": "0xffff"
  }
]

```
