### PR TITLE
Fix spelling mistakes in beacon-state-network.md

### DIFF
--- a/beacon-chain/beacon-state-network.md
+++ b/beacon-chain/beacon-state-network.md
@@ -1,5 +1,5 @@
 ## DHT Overview
-A client has a trusted beacon state root, and it wants to access some parts of the state. Each of the access request corresponds to some leave nodes of the beacon state. The request is a content lookup on a DHT. The response is a Merkle proof. 
+A client has a trusted beacon state root, and it wants to access some parts of the state. Each of the access request corresponds to some leaf nodes of the beacon state. The request is a content lookup on a DHT. The response is a Merkle proof. 
 
 A Distributed Hash Table (DHT) allows network participants to have retrieve data on-demand based on a content key. A portal-network DHT is different than a traditional one in that each participant could selectively limit its workload by choosing a small <em>interest radius</em> `r`. A participants only process messages that are within its chosen radius boundary.
 
@@ -16,7 +16,7 @@ For a subprotocol, we need to further define the following to be able to instant
 1. `content_id` 
 1. `payload`
 
-The content of the message is a Merkle proof contains multiple leave nodes for a [BeaconState](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#beaconstate).
+The content of the message is a Merkle proof contains multiple leaf nodes for a [BeaconState](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#beaconstate).
 
 ```python
 class BeaconState(Container):
@@ -26,11 +26,11 @@ class BeaconState(Container):
     pass
 
 # Used to limit the size of the message. This could be modified to be higher if needed.
-LEAVE_ITEM_LIMIT = 128
+LEAF_ITEM_LIMIT = 128
 
 # The maximum number of proof nodes needed to complete a merkle proof
 # Note that max_chuck_count() is recursively apply chunk_count() on all possible paths of the BeaconState.
-HELPER_INDICES_LIMIT = LEAVE_ITEM_LIMIT * log(max_chuck_count(BeaconState))  
+HELPER_INDICES_LIMIT = LEAF_ITEM_LIMIT * log(max_chuck_count(BeaconState))  
 
 
 class BeaconStateProof(Container):
@@ -38,17 +38,17 @@ class BeaconStateProof(Container):
     See: https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs
     """
     root: Bytes323
-    leave_indices: List[unit64, LEAVE_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
-    leaves: List[Bytes32, LEAVE_ITEM_LIMIT]
+    leaf_indices: List[unit64, LEAF_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
+    leaves: List[Bytes32, LEAF_ITEM_LIMIT]
     branches: List[Bytes32, HELPER_INDICES_LIMIT]
 ```
 
-Finally, we define the necessary encodings. A light client only knows the root of the beacon state. The client wants to know the details of some leave nodes. The client has to be able to construct the `content_key` only knowing the root and which leave nodes it wants see. The `content_key` is the ssz serialization of the paths. The paths represent the part of the beacon state that one wants to know about. The paths are represented by generalized indices. Note that `hash_tree_root` and `serialize` are the same as those defined in [sync-gossip](sync-gossip.md). 
+Finally, we define the necessary encodings. A light client only knows the root of the beacon state. The client wants to know the details of some leaf nodes. The client has to be able to construct the `content_key` only knowing the root and which leaf nodes it wants see. The `content_key` is the ssz serialization of the paths. The paths represent the part of the beacon state that one wants to know about. The paths are represented by generalized indices. Note that `hash_tree_root` and `serialize` are the same as those defined in [sync-gossip](sync-gossip.md). 
 
 ```python
 class BeaconStateProofKey(Container):
     root: Bytes323
-    leave_indices: List[unit64, LEAVE_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
+    leaf_indices: List[unit64, LEAF_ITEM_LIMIT]  # GeneralizedIndex is represented by unit64
 
 
 def get_generalized_index(typ: SSZType, path: Sequence[Union[int, SSZVariableName]]) -> GeneralizedIndex:
@@ -65,7 +65,7 @@ def get_content_key(root: Bytes323, paths: Sequence[Sequence[[Union[int, SSZVari
     indices = [get_generalized_index(BeaconSate, path) for path in paths]
     proof_key = BeaconStateProofKey()
     proof_key.root = root
-    proof_key.leave_indices = indices
+    proof_key.leaf_indices = indices
     return serialize(BeaconStateProofKey, proof_key)
 
 


### PR DESCRIPTION
### What was wrong?
The word leave is used instead of leaf
### How was it fixed?

by renaming the usage of leave with leaf