### PR TITLE
Add validate content jsonrpc query

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -90,6 +90,13 @@
       "$ref": "#/components/schemas/Enr"
     }
   },
+  "ValidateContentResult": {
+    "name": "validateContentResult",
+    "description": "Returns true or false depending on if the client could validate the given data",
+    "schema": {
+      "type": "boolean"
+    }
+  },
   "OfferResult": {
     "name": "offerResult",
     "description": "Returns the content keys bitlist upon successful content transmission or empty bitlist receival",

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -98,6 +98,21 @@
     }
   },
   {
+    "name": "portal_historyValidateContent",
+    "summary": "Returns true or false depending on if the client was able to validate a given history content key and content data.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentValue"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/ValidateContentResult"
+    }
+  },
+  {
     "name": "portal_historyOffer",
     "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
     "params": [

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -98,6 +98,21 @@
     }
   },
   {
+    "name": "portal_stateValidateContent",
+    "summary": "Returns true or false depending on if the client was able to validate a given state content key and content data.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/ContentValue"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/ValidateContentResult"
+    }
+  },
+  {
     "name": "portal_stateOffer",
     "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
     "params": [


### PR DESCRIPTION
Validating content requires access to the network. If we want to validate a block body we were need to query the network for it's respective header with proof for the same block.

Having an easy universial way to verify if client can validate content is helpful for testing/debugging/(maybe some other usecase). Which is a similar case to why we support jsonrpc ``portal_historyStore``. Currently the only way to validate data in a testcase at least on Trin is to seed the required data onto the network, then to make sure the content is valid we recall it with the find_content() command which only returns the data once it is validated. I do believe there is another way but it isn't as clean as stated above.

Hence I think this would be a useful addition to the specs. It seems like I got support on the Trin side to add this jsonrpc so I thought there might be some purpose in also adding it to the specs for its proposed utility.