### PR TITLE
Add slots in content keys for Portal beacon LC types.

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -158,7 +158,7 @@ content_key                = selector + SSZ.serialize(light_client_update_keys)
 #### LightClientFinalityUpdate
 
 ```
-light_client_finality_update_key  = Container(optimistic_slot: uint64, finalized_slot: uint64)
+light_client_finality_update_key  = Container(finalized_slot: uint64)
 selector                          = 0x02
 
 content                           = ForkDigest + SSZ.serialize(light_client_finality_update)
@@ -166,12 +166,13 @@ content_key                       = selector + SSZ.serialize(light_client_finali
 ```
 
 > The `LightClientFinalityUpdate` objects are ephemeral and only the latest is
-of use to the node. The content key requires the `optimistic_slot` and
-`finalized_slot` to be provided so that this object can be more efficiently
-gossiped. Nodes should decide to reject an `LightClientFinalityUpdate` in case
-it is not newer than the one they already have.
-For `FindContent` requests, a node should know the current slot as it is time
-based.
+of use to the node. The content key requires the `finalized_slot` to be provided
+so that this object can be more efficiently gossiped. Nodes should decide to
+reject an `LightClientFinalityUpdate` in case it is not newer than the one they
+already have.
+For `FindContent` requests, a node will either know the last previous finalized
+slot, if it has been following the updates, or it will have to guess slots that
+are potentially finalized.
 
 #### LightClientOptimisticUpdate
 
@@ -183,11 +184,11 @@ content                              = ForkDigest + SSZ.serialize(light_client_o
 content_key                          = selector + SSZ.serialize(light_client_optimistic_update_key)
 ```
 
-> The `LightClientFinalityUpdate` objects are ephemeral and only the latest is
+> The `LightClientOptimisticUpdate` objects are ephemeral and only the latest is
 of use to the node. The content key requires the `optimistic_slot` to be
 provided so that this object can be more efficiently gossiped. Nodes should
-decide to reject an `LightClientFinalityUpdate` in case it is not newer than the
-one they already have.
+decide to reject an `LightClientOptimisticUpdate` in case it is not newer than
+the one they already have.
 For `FindContent` requests, a node should know the current slot as it is time
 based.
 

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -141,7 +141,7 @@ HISTORICAL_ROOTS_LIMIT = 2**24  # = 16,777,216
 light_client_bootstrap_key = Container(block_hash: Bytes32)
 selector                   = 0x00
 
-content                    = ForkDigest || SSZ.serialize(LightlientBootstrap)
+content                    = ForkDigest + SSZ.serialize(LightlientBootstrap)
 content_key                = selector + SSZ.serialize(light_client_bootstrap_key)
 ```
 
@@ -151,7 +151,7 @@ content_key                = selector + SSZ.serialize(light_client_bootstrap_key
 light_client_update_keys   = Container(start_period: uint64, count: uint64)
 selector                   = 0x01
 
-content                    = SSZList(ForkDigest || LightClientUpdate, max_lenght=MAX_REQUEST_LIGHT_CLIENT_UPDATES)
+content                    = SSZList(ForkDigest + LightClientUpdate, max_lenght=MAX_REQUEST_LIGHT_CLIENT_UPDATES)
 content_key                = selector + SSZ.serialize(light_client_update_keys)
 ```
 
@@ -161,7 +161,7 @@ content_key                = selector + SSZ.serialize(light_client_update_keys)
 light_client_finality_update_key  = Container(optimistic_slot: uint64, finalized_slot: uint64)
 selector                          = 0x02
 
-content                           = ForkDigest || SSZ.serialize(light_client_finality_update)
+content                           = ForkDigest + SSZ.serialize(light_client_finality_update)
 content_key                       = selector + SSZ.serialize(light_client_finality_update_key)
 ```
 
@@ -179,7 +179,7 @@ based.
 light_client_optimistic_update_key   = Container(optimistic_slot: uint64)
 selector                             = 0x03
 
-content                              = ForkDigest || SSZ.serialize(light_client_optimistic_update)
+content                              = ForkDigest + SSZ.serialize(light_client_optimistic_update)
 content_key                          = selector + SSZ.serialize(light_client_optimistic_update_key)
 ```
 
@@ -208,7 +208,7 @@ historical_summaries_with_proof = HistoricalSummariesWithProof(
 historical_summaries_key   = 0 (uint8)
 selector                   = 0x04
 
-content                    = ForkDigest || SSZ.serialize(historical_summaries_with_proof)
+content                    = ForkDigest + SSZ.serialize(historical_summaries_with_proof)
 content_key                = selector + SSZ.serialize(historical_summaries_key)
 ```
 

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -158,28 +158,38 @@ content_key                = selector + SSZ.serialize(light_client_update_keys)
 #### LightClientFinalityUpdate
 
 ```
-light_client_finality_update_key  = 0 (uint8)
+light_client_finality_update_key  = Container(optimistic_slot: uint64, finalized_slot: uint64)
 selector                          = 0x02
 
 content                           = ForkDigest || SSZ.serialize(light_client_finality_update)
 content_key                       = selector + SSZ.serialize(light_client_finality_update_key)
 ```
 
-> A `0` in the content key is equivalent to the request for the latest
-LightClientFinalityUpdate that the requested node has available.
+> The `LightClientFinalityUpdate` objects are ephemeral and only the latest is
+of use to the node. The content key requires the `optimistic_slot` and
+`finalized_slot` to be provided so that this object can be more efficiently
+gossiped. Nodes should decide to reject an `LightClientFinalityUpdate` in case
+it is not newer than the one they already have.
+For `FindContent` requests, a node should know the current slot as it is time
+based.
 
 #### LightClientOptimisticUpdate
 
 ```
-light_client_optimistic_update_key   = 0 (uint8)
+light_client_optimistic_update_key   = Container(optimistic_slot: uint64)
 selector                             = 0x03
 
 content                              = ForkDigest || SSZ.serialize(light_client_optimistic_update)
 content_key                          = selector + SSZ.serialize(light_client_optimistic_update_key)
 ```
 
-> A `0` in the content key is equivalent to the request for the latest
-LightClientOptimisticUpdate that the requested node has available.
+> The `LightClientFinalityUpdate` objects are ephemeral and only the latest is
+of use to the node. The content key requires the `optimistic_slot` to be
+provided so that this object can be more efficiently gossiped. Nodes should
+decide to reject an `LightClientFinalityUpdate` in case it is not newer than the
+one they already have.
+For `FindContent` requests, a node should know the current slot as it is time
+based.
 
 #### HistoricalSummaries
 
@@ -189,7 +199,7 @@ HistoricalSummariesProof = Vector[Bytes32, 5]
 
 historical_summaries_with_proof = HistoricalSummariesWithProof(
     epoch: uint64,
-    # HistoricalSummary object is defined in consensus specs: 
+    # HistoricalSummary object is defined in consensus specs:
     # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
     historical_summaries: SSZList(HistoricalSummary, max_length=HISTORICAL_ROOTS_LIMIT),
     proof: HistoricalSummariesProof


### PR DESCRIPTION
Added for the `LightClientFinalityUpdate` and `LightClientOptimisticUpdate` types.

I'm not fully sure about this yet, but I think it is the better approach. Slots are added to the content keys so that nodes can decide not to accept offers when it turns out it is an old update. 
As a counter effect, they do have to provide the current slot when they want to actively request this data (polling approach). I think that is fine as slots are time based.

The other way would involve not adding it to the key, but then, on an offer, a receiving node would have to "guess" what is likely being offered based on the current timestamp.