### PR TITLE
Add utp transfer field to recursive find content result

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -156,8 +156,29 @@
       }
     }
   },
-  "ContentResult": {
-    "name": "ContentResult",
+  "RecursiveFindContentResult": {
+    "name": "RecursiveFindContentResult",
+    "description": "Returns the hex encoded content value and utp transfer flag. If the content is not available, returns \"0x\"",
+    "schema": {
+      "type": "object",
+      "required": [
+        "contentValue",
+        "utpTransfer"
+      ],
+      "properties": {
+        "contentValue": {
+          "description": "Hex encoded content value",
+          "$ref": "#/components/schemas/hexString"
+        },
+        "utpTransfer": {
+          "description": "Indicates whether the content was transferred over a uTP connection or not.",
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "LocalContentResult": {
+    "name": "LocalContentResult",
     "description": "Returns the hex encoded content value. If the content is not available, returns \"0x\"",
     "schema": {
       "type": "object",

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -136,7 +136,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
+      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
     }
   },
   {
@@ -163,7 +163,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
+      "$ref": "#/components/contentDescriptors/LocalContentResult"
     }
   },
   {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -136,7 +136,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
+      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
     }
   },
   {
@@ -163,7 +163,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/ContentResult"
+      "$ref": "#/components/contentDescriptors/LocalContentResult"
     }
   },
   {


### PR DESCRIPTION
To maintain consistency with find content responses, we should support a `utp_transfer` boolean in recursive find content responses.