### PR TITLE
Clarify slot to be used in `OptimisticUpdate` content key

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -205,7 +205,7 @@ content_key                          = selector + SSZ.serialize(light_client_opt
 
 > The `LightClientOptimisticUpdate` objects are ephemeral and only the latest is
 of use to the node. The content key requires the `optimistic_slot` (corresponding to
-the `slot` in the `attested_header` contained in the update to be provided so that this
+the `slot` in the `attested_header` contained in the update) to be provided so that this
 object can be more efficiently gossiped. Nodes should decide to reject an
 `LightClientOptimisticUpdate` in case it is not newer than the one they already have.
 For `FindContent` requests, a node should compute the current slot based on its local clock

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -205,11 +205,11 @@ content_key                          = selector + SSZ.serialize(light_client_opt
 
 > The `LightClientOptimisticUpdate` objects are ephemeral and only the latest is
 of use to the node. The content key requires the `optimistic_slot` (corresponding to
-the `slot` in the `attested_header` contained in the update) to be provided so that this
+the `signature_slot` in the the update) to be provided so that this
 object can be more efficiently gossiped. Nodes should decide to reject an
 `LightClientOptimisticUpdate` in case it is not newer than the one they already have.
 For `FindContent` requests, a node should compute the current slot based on its local clock
-and then use that slot minus 1 as a starting point for retrieving the most recent update.
+and then use that slot as a starting point for retrieving the most recent update.
 
 #### HistoricalSummaries
 

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -204,12 +204,12 @@ content_key                          = selector + SSZ.serialize(light_client_opt
 ```
 
 > The `LightClientOptimisticUpdate` objects are ephemeral and only the latest is
-of use to the node. The content key requires the `optimistic_slot` to be
-provided so that this object can be more efficiently gossiped. Nodes should
-decide to reject an `LightClientOptimisticUpdate` in case it is not newer than
-the one they already have.
-For `FindContent` requests, a node should know the current slot as it is time
-based.
+of use to the node. The content key requires the `optimistic_slot` (corresponding to
+the `slot` in the `attested_header` contained in the update to be provided so that this
+object can be more efficiently gossiped. Nodes should decide to reject an
+`LightClientOptimisticUpdate` in case it is not newer than the one they already have.
+For `FindContent` requests, a node should compute the current slot based on its local clock
+and then use that slot minus 1 as a starting point for retrieving the most recent update.
 
 #### HistoricalSummaries
 


### PR DESCRIPTION
There is some ambiguity in the spec related to the `optimistic_slot` in the  `LightClientOptimisticUpdate` key and this adds clarification that this slot should match the slot of the attested header in the requested `LightClientOptimisticUpdate` (which on best case will always be 1 slot behind the current slot as computed by the node's local clock).