### PR TITLE
Unique selector bytes for History, Beacon, and State networks

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -155,7 +155,7 @@ HISTORICAL_ROOTS_LIMIT = 2**24  # = 16,777,216
 
 ```
 light_client_bootstrap_key = Container(block_hash: Bytes32)
-selector                   = 0x00
+selector                   = 0x10
 
 content                    = ForkDigest + SSZ.serialize(LightlientBootstrap)
 content_key                = selector + SSZ.serialize(light_client_bootstrap_key)
@@ -165,7 +165,7 @@ content_key                = selector + SSZ.serialize(light_client_bootstrap_key
 
 ```
 light_client_update_keys   = Container(start_period: uint64, count: uint64)
-selector                   = 0x01
+selector                   = 0x11
 
 content                    = SSZList(ForkDigest + LightClientUpdate, max_lenght=MAX_REQUEST_LIGHT_CLIENT_UPDATES)
 content_key                = selector + SSZ.serialize(light_client_update_keys)
@@ -178,7 +178,7 @@ the requested range it MUST NOT reply any content.
 
 ```
 light_client_finality_update_key  = Container(finalized_slot: uint64)
-selector                          = 0x02
+selector                          = 0x12
 
 content                           = ForkDigest + SSZ.serialize(light_client_finality_update)
 content_key                       = selector + SSZ.serialize(light_client_finality_update_key)
@@ -197,7 +197,7 @@ are potentially finalized.
 
 ```
 light_client_optimistic_update_key   = Container(optimistic_slot: uint64)
-selector                             = 0x03
+selector                             = 0x13
 
 content                              = ForkDigest + SSZ.serialize(light_client_optimistic_update)
 content_key                          = selector + SSZ.serialize(light_client_optimistic_update_key)
@@ -226,7 +226,7 @@ historical_summaries_with_proof = HistoricalSummariesWithProof(
 )
 
 historical_summaries_key   = 0 (uint8)
-selector                   = 0x04
+selector                   = 0x14
 
 content                    = ForkDigest + SSZ.serialize(historical_summaries_with_proof)
 content_key                = selector + SSZ.serialize(historical_summaries_key)

--- a/state-network.md
+++ b/state-network.md
@@ -140,7 +140,7 @@ A leaf node from the main account trie and accompanying merkle proof against a r
 
 ```
 account_trie_proof_key := Container(address: Bytes20, state_root: Bytes32)
-selector               := 0x00
+selector               := 0x20
 
 content                := Container(witness: MPTWitness)
 content_id             := keccak(address)
@@ -153,7 +153,7 @@ A leaf node from a contract storage trie and accompanying merkle proof against t
 
 ```
 storage_trie_proof_key := Container(address: Bytes20, slot: uint256, state_root: Bytes32)
-selector               := 0x01
+selector               := 0x21
 
 content                := Container(witness: MPTWitness)
 content_id             := (keccak(address) + keccak(slot)) % 2**256
@@ -166,7 +166,7 @@ The bytecode for a specific contract as referenced by `Account.code_hash`
 
 ```
 contract_bytecode_key := Container(address: Bytes20, code_hash: Bytes32)
-selector              := 0x02
+selector              := 0x22
 
 content               := ByteList(24756)  // Represents maximum possible size of contract bytecode
 content_id            := sha256(address + code_hash)


### PR DESCRIPTION
Content keys on different portal networks can and do have overlapping selectors. For example the first byte of a history header content key is `0x00` and the first byte of a beacon bootstrap content key is `0x00`. 

I'm proposing that, as convention, we un-overlap these selectors for the sake of clarity. I'm **not** proposing that we make it required that these not overlap, which would put a limit on the number of auxillary networks (eg ethstorage) that can be built in the future.

The motivation for doing this is the ambiguity that it removes. With overlapping selectors a given content key needs to always be accompanied by information about which network it belongs to, otherwise it means nothing to the parser/reader. I think that this ambiguity will become a frustration while developing/debugging/discussing multi-subnet portal clients and the software that uses them.

History network keeps its selectors, so not much live data would need to be dumped to do this. Only beacon which is young enough for this to be a good time to make this change if we choose to. 
