### PR TITLE
docs: change gossip rpc return to accepted count instead of offered count

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -192,7 +192,7 @@
   },
   "GossipResult": {
     "name": "gossipResult",
-    "description": "Returns the number of peers that the content was gossiped to",
+    "description": "Returns the number of peers that accepted the gossiped content",
     "schema": {
       "title": "number of peers",
       "type": "number"


### PR DESCRIPTION
Currently ``portal_historyGossip`` returns the amount of nodes we offered the content to but this metric isn't very useful as for all we know the nodes it offered the content to could be dead or even worse didn't accept the content in the first place.

That is why I propose we switch ``portal_historyGossip`` to return the amount of nodes that accepted the content instead. This idea was taken from Jason Carver in Trin chat on the Portal Discord. I ended up implementing it on Trin and it was 1000 times easier to know what was going on where before I would see a number ``8`` half sometimes the content would be accepted by 0 nodes and then it was hard to even know if gossip did anything.

If ``portal_historyGossip`` gossip's to 8 nodes and 0 nodes accept the content. At that point it doesn't matter if ``portal_historyGossip`` returns 8 or 8000 the number doesn't say anything if none accepted it.