### PR TITLE
change all contentValue keys in return objects to content

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -162,11 +162,11 @@
     "schema": {
       "type": "object",
       "required": [
-        "contentValue",
+        "content",
         "utpTransfer"
       ],
       "properties": {
-        "contentValue": {
+        "content": {
           "description": "Hex encoded content value",
           "$ref": "#/components/schemas/hexString"
         },
@@ -183,7 +183,7 @@
     "schema": {
       "type": "object",
       "properties": {
-        "contentValue": {
+        "content": {
           "description": "Hex encoded content value",
           "$ref": "#/components/schemas/hexString"
         }


### PR DESCRIPTION
Small addition to the previous one (https://github.com/ethereum/portal-network-specs/pull/236). Let's make our return values consistent to each other and to the spec.
I'll create issues for each of the clients and collect them all here.