### PR TITLE
state_network spec updates

### DIFF
--- a/state-network.md
+++ b/state-network.md
@@ -42,6 +42,32 @@ The state network uses the stock XOR distance metric defined in the portal wire 
 
 The derivation function for Content Id values are defined separately for each data type.
 
+#### Path Aware Content ID Derivation
+
+The state network is primarily concerned with storing state data which is
+cryptographically anchored into trie structure.  A naive approach to
+distribution of this data in the network would be to address trie nodes by
+their node-hash.  This approach is effective, however, it negatively impacts
+the efficiency of lookups.  The production patricia merkle trie for ethereum
+accounts tends to be at least 7 layers deep, which in a production portal
+network environment would mean nodes would have to perform seven (7) recursive
+lookups in the DHT to find a single piece of state.
+
+For this reason, the state network implements a custom scheme that uses the
+trie path for the high bits in the content-id and fills the remaining low bits
+from the node hash.  The result of this is as follows.
+
+- Content that is very *shallow* in the trie such as the state root node is
+  relatively randomly distributed around the DHT regardless of the path
+  component.
+- Content that is very deep in the trie such as leaf nodes, or deep
+  intermediate nodes are clustered in the DHT address space with the most bits
+  in common with the path to those nodes in the trie.
+
+This leads to a beneficial situation where leaves that are *close* to each
+other in the trie will also be likely to be close to each other in the DHT,
+which allows for more efficient network retrieval.
+
 ### Wire Protocol
 
 #### Protocol Identifier

--- a/state-network.md
+++ b/state-network.md
@@ -131,7 +131,9 @@ StorageWitness         := Container(key: Nibbles, proof: Witness, state_proof: S
 
 The `StateWitness.key` denotes the path to the trie node that is proven by the `StateWitness.proof`.  The same applies to `StorageWitness.key` and `StorageWitness.proof`.
 
-The `MTPWitness` is subject to the following validity requirements.
+The `StorageWitness.state_proof` MUST be for a leaf node in the account trie.  The `StorageWitness.proof` must be anchored to the contract state root denoted by the account from the `StorageWitness.state_proof`.
+
+All `Witness` objects are subject to the following validity requirements.
 
 - The nodes in a `Witness` MUST be lexically ordered by their path in the trie.
 - A `Witness` may not contain any superfluous nodes that are not needed for proving.
@@ -145,7 +147,7 @@ The `MTPWitness` is subject to the following validity requirements.
 account_trie_node_key  := Container(path: Nibbles, node_hash: Bytes32)
 selector               := 0x20
 
-content_for_offer      := Container(proof: MPTWitness, block_hash: Bytes32)
+content_for_offer      := Container(proof: StateWitness, block_hash: Bytes32)
 content_for_retrieval  := Container(node: WitnessNode)
 content_key            := selector + SSZ.serialize(account_trie_node_key)
 content_id             := sha256(content_key)
@@ -158,7 +160,7 @@ content_id             := sha256(content_key)
 storage_trie_node_key  := Container(address: Address, path: Nibbles, node_hash: Bytes32)
 selector               := 0x21
 
-content_for_offer      :=  Container(account_proof: MPTWitness, storage_proof: MPTWitness, block_hash: Bytes32)
+content_for_offer      :=  Container(proof: StorageWitness, block_hash: Bytes32)
 content_for_retrieval  :=  Container(node: WitnessNode)
 content_key            :=  selector + SSZ.serialize(storage_trie_node_key)
 content_id             :=  sha256(content_key)
@@ -174,7 +176,7 @@ Problematic!
 contract_code_key      := Container(address: Address, code_hash: Bytes32)
 selector               := 0x22
 
-content_for_offer      := Container(code: ByteList, account_proof: MPTWitness, block_hash: Bytes32)
+content_for_offer      := Container(code: ByteList, account_proof: StateWitness, block_hash: Bytes32)
 content_for_retrieval  := Container(code: ByteList)
 content_key            := selector + SSZ.serialize(contract_code_key)
 content_id             := sha256(content_key)
@@ -327,6 +329,8 @@ state root node of the trie.
 
 
 ### Gossip 
+
+> TODO: this section still needs to be updated.
 
 Each time a new block is added to their view of the chain, a set of merkle proofs which are all anchored to `Header.state_root` is generated which contains:
 

--- a/state-network.md
+++ b/state-network.md
@@ -3,6 +3,7 @@
 This document is the specification for the sub-protocol that supports on-demand availability of state data from the execution chain.
 
 > 🚧 THE SPEC IS IN A STATE OF FLUX AND SHOULD BE CONSIDERED UNSTABLE 🚧
+> 🚧 12/12/23 🚧 WIP: STATE_NETWORK_SPEC v2 🚧 NEW_STATENETWORK_BOOGIE 🚧
 
 ## Overview
 

--- a/state-network.md
+++ b/state-network.md
@@ -37,7 +37,7 @@ The state network uses the stock XOR distance metric defined in the portal wire 
 
 ### Content ID Derivation Function
 
-The history network uses the SHA256 Content ID derivation function from the portal wire protocol specification.
+The state network uses the SHA256 Content ID derivation function from the portal wire protocol specification.
 
 ### Wire Protocol
 
@@ -169,7 +169,6 @@ account_trie_node_key  := Container(path: Nibbles, node_hash: Bytes32)
 selector               := 0x20
 
 content_key            := selector + SSZ.serialize(account_trie_node_key)
-content_id             := sha256(content_key)
 ```
 
 ##### Account Trie Node: OFFER/ACCEPT
@@ -199,7 +198,6 @@ storage_trie_node_key  := Container(address: Address, path: Nibbles, node_hash: 
 selector               := 0x21
 
 content_key            := selector + SSZ.serialize(storage_trie_node_key)
-content_id             := sha256(content_key)
 ```
 
 
@@ -233,7 +231,6 @@ contract_code_key      := Container(address: Address, code_hash: Bytes32)
 selector               := 0x22
 
 content_key            := selector + SSZ.serialize(contract_code_key)
-content_id             := sha256(content_key)
 ```
 
 

--- a/state-network.md
+++ b/state-network.md
@@ -106,11 +106,16 @@ NibblePair := Byte  # 2 nibbles tightly packed into a single byte
 Nibbles    := Container(is_odd_length=bool, packed_nibbles=List(NibblePair, max_length=32))
 ```
 
-`Nibbles.packed_nibbles` is a sequence of bytes with each byte containing two
-nibbles.  When encoding an odd length sequence of nibbles the high bits of the
-final byte should be left empty and `Nibbles.is_odd_length` boolean flag should be
-set to `True`.
+`NibblePair` is packed so that nibble that goes first in the path uses high bits, while later nibble uses lower bits.
 
+`Nibbles.packed_nibbles` is a sequence of bytes with each byte containing two nibbles.  When encoding an odd length sequence of nibbles, `Nibbles.is_odd_length` boolean flag MUST be set to `True`, the high bits of the first byte MUST be left empty, first nibble MUST use low bits of the first byte, and remaning nibbles are tightly packed in remaining bytes.
+
+Examples:
+
+```
+[1, 2, a, b] -> Nibbles(is_odd_length=false, packed_nibbles=[0x12, 0xab])
+[1, 2, a, b, c] -> Nibbles(is_odd_length=true, packed_nibbles=[0x01, 0x2a, 0xbc])
+```
 
 ##### Merkle Patricia Trie (MPT) Proofs
 

--- a/state-network.md
+++ b/state-network.md
@@ -162,7 +162,7 @@ single pass.
 
 #### Account Trie Node
 
-This data types represent a node from the main state trie.
+These data types represent a node from the main state trie.
 
 ```
 account_trie_node_key  := Container(path: Nibbles, node_hash: Bytes32)
@@ -174,7 +174,7 @@ content_id             := sha256(content_key)
 
 ##### Account Trie Node: OFFER/ACCEPT
 
-This type is used when content offered via OFFER/ACCEPT.
+This type MUST be used when content offered via OFFER/ACCEPT.
 
 ```
 content_for_offer      := Container(proof: StateWitness, block_hash: Bytes32)
@@ -183,7 +183,7 @@ content_for_offer      := Container(proof: StateWitness, block_hash: Bytes32)
 
 ##### Account Trie Node: FINDCONTENT/FOUNDCONTENT
 
-This type is used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
+This type MUST be used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
 
 ```
 content_for_retrieval := Container(node: WitnessNode)
@@ -192,7 +192,7 @@ content_for_retrieval := Container(node: WitnessNode)
 
 #### Contract Trie Node
 
-This data types represent a node from an individual contract storage trie.
+These data types represent a node from an individual contract storage trie.
 
 ```
 storage_trie_node_key  := Container(address: Address, path: Nibbles, node_hash: Bytes32)
@@ -205,7 +205,7 @@ content_id             := sha256(content_key)
 
 ##### Contract Trie Node: OFFER/ACCEPT
 
-This type is used when content offered via OFFER/ACCEPT.
+This type MUST be used when content offered via OFFER/ACCEPT.
 
 ```
 content_for_offer      := Container(proof: StorageWitness, block_hash: Bytes32)
@@ -214,7 +214,7 @@ content_for_offer      := Container(proof: StorageWitness, block_hash: Bytes32)
 
 ##### Contract Trie Node: FINDCONTENT/FOUNDCONTENT
 
-This type is used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
+This type MUST be used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
 
 ```
 content_for_retrieval  := Container(node: WitnessNode)
@@ -223,7 +223,7 @@ content_for_retrieval  := Container(node: WitnessNode)
 
 #### Contract Code
 
-This data types represent the bytecode for a contract.
+These data types represent the bytecode for a contract.
 
 > NOTE: Because CREATE2 opcode allows for redeployment of new code at an existing address, we MUST randomly distribute contract code storage across the DHT keyspace to avoid hotspots developing in the network for any contract that has had many different code deployments.  Were we to use the path based *high-bits* approach for computing the content-id, it would be possible for a single location in the network to accumulate a large number of contract code objects that all live in roughly the same space.
 Problematic!
@@ -239,7 +239,7 @@ content_id             := sha256(content_key)
 
 ##### Contract Code: OFFER/ACCEPT
 
-This types is used when content offered via OFFER/ACCEPT.
+This types MUST be used when content offered via OFFER/ACCEPT.
 
 ```
 content_for_offer      := Container(code: ByteList, account_proof: StateWitness, block_hash: Bytes32)
@@ -248,7 +248,7 @@ content_for_offer      := Container(code: ByteList, account_proof: StateWitness,
 
 ##### Contract Code: FINDCONTENT/FOUNDCONTENT
 
-This type is used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
+This type MUST be used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
 
 ```
 content_for_retrieval  := Container(code: ByteList)

--- a/state-network.md
+++ b/state-network.md
@@ -369,6 +369,7 @@ contains:
 - All contract bytecode for newly created contracts
 
 A bridge should compute the content-id values for all of this new state data
-and sort the data by proximity to its own node-id.  Beginning with the content
-that is *closest* to its own node-id it should proceed to GOSSIP each
-individual piece of content to nodes interested in that content.
+that should be part of the "inception" round of recursive gossip.  These pieces
+of content should be sorted by proximity to its own node-id.  Beginning with
+the content that is *closest* to its own node-id it should proceed to GOSSIP
+each individual piece of content to nodes interested in that content.

--- a/state-network.md
+++ b/state-network.md
@@ -162,38 +162,68 @@ single pass.
 
 #### Account Trie Node
 
-This data type represents a node from the main state trie.
-
+This data types represent a node from the main state trie.
 
 ```
 account_trie_node_key  := Container(path: Nibbles, node_hash: Bytes32)
 selector               := 0x20
 
-content_for_offer      := Container(proof: StateWitness, block_hash: Bytes32)
-content_for_retrieval  := Container(node: WitnessNode)
 content_key            := selector + SSZ.serialize(account_trie_node_key)
 content_id             := sha256(content_key)
 ```
 
+##### Account Trie Node: OFFER/ACCEPT
+
+This type is used when content offered via OFFER/ACCEPT.
+
+```
+content_for_offer      := Container(proof: StateWitness, block_hash: Bytes32)
+```
+
+
+##### Account Trie Node: FINDCONTENT/FOUNDCONTENT
+
+This type is used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
+
+```
+content_for_retrieval := Container(node: WitnessNode)
+```
+
+
 #### Contract Trie Node
 
-This data type represents a node from an individual contract storage trie.
-
+This data types represent a node from an individual contract storage trie.
 
 ```
 storage_trie_node_key  := Container(address: Address, path: Nibbles, node_hash: Bytes32)
 selector               := 0x21
 
-content_for_offer      :=  Container(proof: StorageWitness, block_hash: Bytes32)
-content_for_retrieval  :=  Container(node: WitnessNode)
-content_key            :=  selector + SSZ.serialize(storage_trie_node_key)
-content_id             :=  sha256(content_key)
+content_key            := selector + SSZ.serialize(storage_trie_node_key)
+content_id             := sha256(content_key)
+```
+
+
+##### Contract Trie Node: OFFER/ACCEPT
+
+This type is used when content offered via OFFER/ACCEPT.
+
+```
+content_for_offer      := Container(proof: StorageWitness, block_hash: Bytes32)
+```
+
+
+##### Contract Trie Node: FINDCONTENT/FOUNDCONTENT
+
+This type is used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
+
+```
+content_for_retrieval  := Container(node: WitnessNode)
 ```
 
 
 #### Contract Code
 
-This data type represents the bytecode for a contract.
+This data types represent the bytecode for a contract.
 
 > NOTE: Because CREATE2 opcode allows for redeployment of new code at an existing address, we MUST randomly distribute contract code storage across the DHT keyspace to avoid hotspots developing in the network for any contract that has had many different code deployments.  Were we to use the path based *high-bits* approach for computing the content-id, it would be possible for a single location in the network to accumulate a large number of contract code objects that all live in roughly the same space.
 Problematic!
@@ -202,10 +232,26 @@ Problematic!
 contract_code_key      := Container(address: Address, code_hash: Bytes32)
 selector               := 0x22
 
-content_for_offer      := Container(code: ByteList, account_proof: StateWitness, block_hash: Bytes32)
-content_for_retrieval  := Container(code: ByteList)
 content_key            := selector + SSZ.serialize(contract_code_key)
 content_id             := sha256(content_key)
+```
+
+
+##### Contract Code: OFFER/ACCEPT
+
+This types is used when content offered via OFFER/ACCEPT.
+
+```
+content_for_offer      := Container(code: ByteList, account_proof: StateWitness, block_hash: Bytes32)
+```
+
+
+##### Contract Code: FINDCONTENT/FOUNDCONTENT
+
+This type is used when content retrieved from another node via FINDCONTENT/FOUNDCONTENT.
+
+```
+content_for_retrieval  := Container(code: ByteList)
 ```
 
 

--- a/state-network.md
+++ b/state-network.md
@@ -136,13 +136,12 @@ All `Witness` objects are subject to the following validity requirements.
 
 - A: Lexical Ordering
 - B: No Extraneous Nodes
-- C: No Redundant Nodes
 
 ###### A: Lexical Ordering
 
 The sequence of nodes in the witness MUST be lexically ordered by their nibbles
-path in the trie.  This results in the state root node always occuring first in
-the list of trie nodes.
+path in the trie.  This results in the state root node always occuring first and
+node being proven last in the list of trie nodes.
 
 > This validity condition is to ensure that verifcation of the proof can be done
 in a single pass.
@@ -152,17 +151,6 @@ in a single pass.
 A witness MUST NOT contain any nodes that are not part of the set needed to for proving.  
 
 > This validity condition is to protect against malicious or erroneous bloating of proof payloads.
-
-###### C: No Redundant Nodes
-
-A witness MUST NOT contain any nodes that can be computed from other nodes in
-the proof.  For example, the inclusion of a parent node along with the
-inclusion of all of that node's children since the parent node can be
-reconstructed from the children.
-
-> This validity condition is to protect against malicious or erroneous bloating
-of proof payloads and to ensure that verification of proofs can be done in a
-single pass.
 
 
 #### Account Trie Node
@@ -259,165 +247,73 @@ content_for_retrieval  := Container(code: ByteList)
 
 ## Gossip
 
-As each new block is added to the chain, the state from that block must be gossiped into the network.  
-The state network defines a specific gossip algorithm which is referred to as "Recursive Gossip".  This 
-section of the specification defines how this gossip mechanism works.
-
+As each new block is added to the chain, the state from that block must be gossiped into the network.
+The state network defines a specific gossip algorithm which is referred to as "Recursive Gossip".
+This section of the specification defines how this gossip mechanism works.
 
 ### Terminology
 
-We define the following terms when referring to state data.
+The Merkle Patricia Trie (MPT) has three types of nodes: *"branch"*, *"extension"* and *"leaf"*.
+The MPT also specifies the `nil` node, but it will never be sent or stored over network, so we will
+ignore it for this spec.
 
-> The diagrams below use a binary trie for visual simplicity. The same
-> definitions naturally extend to the hexary patricia trie.
+Similarly to other tree structure, the `leaf` node is the lowest node on a certain path and it's
+where value is stored in the tree (strictly speaking, MPT allows value to be stored in `branch`
+nodes as well, but Ethreum storage doesn't use this functionality). The `branch` and `extension`
+nodes can be called `intermediate` nodes because there will always be a node that can only be
+reached by passing through them.
 
+A *"merkle proof"* or *"proof"* is a collection of nodes from the trie sufficient to recompute the
+state root and prove that *"target"* node is part of the trie defined by that state root. A proof is:
 
-```
-0:                           X
-                            / \
-                          /     \
-                        /         \
-                      /             \
-                    /                 \
-                  /                     \
-                /                         \
-1:             0                           1
-             /   \                       /   \
-           /       \                   /       \
-         /           \               /           \
-2:      0             1             0             1
-       / \           / \           / \           / \
-      /   \         /   \         /   \         /   \
-3:   0     1       0     1       0     1       0     1
-    / \   / \     / \   / \     / \   / \     / \   / \
-4: 0   1 0   1   0   1 0   1   0   1 0   1   0   1 0   1
-```
-
-#### *"state root"*
-
-The node labeled `X` in the diagram found at level 0 or the "root" of the trie.
-
-#### *"trie node"*
-
-Any of the individual nodes in the trie represented by either `X` for the state root node, or a `1` or `0` for trie nodes.
-
-#### *"intermediate node"*
-
-Any of the nodes in the trie which are computed from other nodes in the trie.  The nodes in the diagram at levels 0, 1, 2, and 3 are all intermediate.
-
-#### *"leaf node"*
-
-Any node in the trie that represents a value stored in the trie.  The nodes in the diagram at level 4 are leaf nodes.
-
-#### *"merkle proof"* or *"proof"*
-
-A collection of nodes from the trie sufficient to recompute the state root and prove that one or more nodes are part of the trie defined by that state root.
-
-> A proof is considered to be "minimal" if it contains only the minimum set of trie nodes needed to recompute the state root.
-
+- *"ordered"*
+    - the order of the nodes in the proof have to represent the path from root node to the target node
+        - first node must be the root node, followed by zero or more intermediate nodes, ending
+        with a target node
+        - it should be provable that any non-first node is part of the preceding node
+    - if root node is the target node, then the proof will only contain the root node
+    - the target node can be of any type (branch, extension or leaf)
+- *"minimal"*
+    - it contains only the nodes from on a path from the root node to the target node
 
 ### Overview
 
-The goal of the "recursive gossip" mechanism is to reduce the burden of
-responsibility placed on bridge nodes for injecting new state data into the
-network while simultaniously spreading the responsibility for gossiping new
-state data across the nodes in the network.
+We will give the overview of the process for the account trie. The same process should be applied
+for the storage trie as well.
 
-At each block we construct a proof against the new state root which contains
-all of the state changes which occured within that block.  
+The goal of the "recursive gossip" mechanism is to reduce the burden of responsibility placed on
+bridge nodes for injecting new state data into the network while simultaniously spreading the
+responsibility for gossiping new state data across the nodes in the network.
 
-This proof contains *explicitly* a mixed set of leaf and intermediate
-nodes, as well as implicitly a set of intermediate nodes which can be
-computed from the nodes that are part of the proof.
+At each block we construct a proof for each new or modified value in the trie, which is stored in
+the leaf nodes. The bridge node would search the DHT for nodes that are *interested* in storing
+each leaf node and gossip the proof to those nodes.
 
-```
-EXAMPLE: Recursive Gossip Inception
+> For example, let this be the proof: `[A, B, C, D, E, F]`, then `A` is the root note and `F` is
+> the target node. This proof should be gossiped to nodes that are interested in storing node `F`.
 
-0:                           A*
-                            / \
-                          /     \
-                        /         \
-                      /             \
-                    /                 \
-                  /                     \
-                /                         \
-1:             B*                          C
-             /   \
-           /       \
-         /           \
-2:      D             E*
-                     / \
-                    /   \
-3:                 F     G*
-                        / \
-4:                     H*  I
+The recipients of this gossip are then responsible for gossiping the penultimate node of the proof
+(parent of the target node, `E` in our example). To do so, they would strip the last (target) node
+from the proof, search the DHT for nodes that are interested in `E` and gossip this proof to them.
 
-- "*" denotes trie node modified
-```
-
-In the example proof diagramed here we can see a *leaf* node `H` which
-represents the only modified leaf state in this proof.  Note that all of the
-nodes along the path leading to `H` are also modified.
-
-The *minimal* proof would contain the nodes `[D, F, H, I, C]`
-
-The bridge node would search the DHT for nodes that are *interested* in storing
-the node `H` and gossip this proof to those nodes.
-
-The recipients of this gossip are then responsible for gossiping the parent
-intermediate node `G`.  To do so, they would strip off the `H` and `I` nodes
-from this proof resulting in the following:
-
-```
-EXAMPLE: Recursive Gossip Round 1
-
-0:                           A*
-                            / \
-                          /     \
-                        /         \
-                      /             \
-                    /                 \
-                  /                     \
-                /                         \
-1:             B*                          C
-             /   \
-           /       \
-         /           \
-2:      D             E*
-                     / \
-                    /   \
-3:                 F     G*
-
-4:
-```
-
-At this stage, the minimal proof for `G` would be `[D, F, G, C]`.  The nodes
-which received the initial gossip message for `H` would construct this proof
-by removing the un-necessary nodes, after which they would search the DHT for
-nodes that are interested in `F` and gossip this proof to them..
-
-The recipients of that gossip are then responsible for gossiping the parent
-intermediate node `E`.  This process repeats until it terminates at the state
-root, with the final round of gossip only containing the `[A]` which is the
-state root node of the trie.
-
+This process repeats until it terminates at the state root, with the final round of gossip only
+containing the `[A]` which is the state root node of the trie.
 
 ### Bridge Node Responsibilities
 
-Each time a new block is added to their view of the chain, a set of merkle
-proofs which are all anchored to `Header.state_root` is generated which
-contains:
+The bridge is responsible for creating and gossiping all following data and their proofs:
 
-- Account trie Data:
-    - All of the new and modified account nodes from the state trie.
-    - All of the intermediate and leaf trie nodes from the account trie necessary to prove new and modified accounts.
-- Contract Storage trie data:
-    - All of the new and modified storage slots from each modified contract storage trie.
-    - All of the intermediate and leaf trie nodes from each contract storage trie necessary to prove new and modified storage slots.
-- All contract bytecode for newly created contracts
+- account trie data:
+    - all of the new and modified account nodes from the state trie
+- contract storage trie data:
+    - all of the new and modified storage slots from each modified contract storage trie
+    - proof has to include the proof for the account trie that corresponds to the same contract
+    - recursive gossip stops at the root of the storage trie
+- all contract bytecode for newly created contracts
+    - proof has to include the proof for the account trie that corresponds to the same contract
+    - recursive gossip doesn't happen in this case
 
-A bridge should compute the content-id values for all of this new state data
-that should be part of the "inception" round of recursive gossip.  These pieces
-of content should be sorted by proximity to its own node-id.  Beginning with
-the content that is *closest* to its own node-id it should proceed to GOSSIP
-each individual piece of content to nodes interested in that content.
+A bridge should compute the content-id values for all proofs that are part of the initial round of
+recursive gossip. These proofs should be sorted by proximity to its own node-id. Beginning with
+the content that is *closest* to its own node-id it should proceed to GOSSIP each individual proof
+to nodes interested in that content.

--- a/state-network.md
+++ b/state-network.md
@@ -2,9 +2,6 @@
 
 This document is the specification for the sub-protocol that supports on-demand availability of state data from the execution chain.
 
-> 🚧 THE SPEC IS IN A STATE OF FLUX AND SHOULD BE CONSIDERED UNSTABLE 🚧
-> 🚧 12/12/23 🚧 WIP: STATE_NETWORK_SPEC v2 🚧 NEW_STATENETWORK_BOOGIE 🚧
-
 ## Overview
 
 The execution state network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](./portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
@@ -95,13 +92,13 @@ The OFFER/ACCEPT payloads need to be provable by their recipients.  These proofs
 The FINDCONTENT/FOUNDCONTENT payloads do not contain proofs because a piece of state can exist under many different state roots.  All payloads can still be proved to be the correct requested data, however, it is the responsibility of the requesting party to anchor the returned data as canonical chain state data.
 
 
-#### Component Data Elements
+#### Helper Data Types
 
-#### Paths (Nibbles)
+##### Paths (Nibbles)
 
 A naive approach to storage of trie nodes would be to simply use the `node_hash` value of the trie node for storage.  This scheme however results in stored data not being tied in any direct way to it's location in the trie.  In a situation where a participant in the DHT wished to re-gossip data that they have stored, they would need to reconstruct a valid trie proof for that data in order to construct the appropriate OFFER/ACCEPT payload.  We include the `path` metadata in state network content keys so that it is possible to reconstruct this proof.
 
-We define path as a sequences of "nibbles" which represent the path through the MPT to reach the trie node.
+We define path as a sequences of "nibbles" which represent the path through the merkle patritia trie (MPT) to reach the trie node.
 
 ```
 nibble     := {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, a, b, c, d, e, f}
@@ -115,12 +112,9 @@ final byte should be left empty and `Nibbles.is_odd_length` boolean flag should 
 set to `True`.
 
 
-#### Merkle Patricia Trie (MPT) Proofs
+##### Merkle Patricia Trie (MPT) Proofs
 
 Merkle Patricia Trie (MPT) proofs consist of a list of witness nodes that correspond to each trie node that consists of various data elements depending on the type of node (e.g.blank, branch, extension, leaf).  When serialized, each witness node is represented as an RLP serialized list of the component elements with the largest possible node type being the branch node which when serialized is a list of up to sixteen hashes in `Bytes32` (representing the hashes of each of the 16 nodes in that branch and level of the tree) plus the 4 elements of the node's value (balance, nonce, codehash, storageroot) represented as `Bytes32`.  When combined with the RLP prefixes, this yields a possible maximum length of 667 bytes.  We specify 1024 as the maximum length due to constraints in the SSZ spec for list lengths being a power of 2 (for easier merkleization.)
-
-> TODO: Define proof such that there is one canonical representation of a witness that is streamable and minimal??
-> Specs should specify order of proof nodes, and disallow inclusion of superflous nodes.
 
 ```
 WitnessNode            := ByteList(1024)
@@ -135,9 +129,35 @@ The `StorageWitness.state_proof` MUST be for a leaf node in the account trie.  T
 
 All `Witness` objects are subject to the following validity requirements.
 
-- The nodes in a `Witness` MUST be lexically ordered by their path in the trie.
-- A `Witness` may not contain any superfluous nodes that are not needed for proving.
-- A `Witness` may not contain any superfluous nodes that could be computed from other nodes that are part of the proof.
+- A: The nodes in a `Witness` MUST be lexically ordered by their path in the trie.
+- B: The `Witness` MUST NOT contain any superfluous nodes that are not needed for proving.
+- C: The `Witness` MUST NOT contain any superfluous nodes that could be computed from other nodes that are part of the proof.
+
+###### A: Lexical Ordering
+
+The sequence of nodes in the witness must be lexically ordered by their nibbles
+path in the trie.  This results in the state root node always occuring first in
+the list of trie nodes.
+
+> This validity condition is to ensure that verifcation of the proof can be done
+in a single pass.
+
+###### B: No Extraneous Nodes
+
+A witness MUST NOT contain any nodes that are not part of the set needed to for proving.  
+
+> This validity condition is to protect against malicious or erroneous bloating of proof payloads.
+
+##### C: No Redundant Nodes
+
+A witness MUST NOT contain any nodes that can be computed from other nodes in
+the proof.  For example, the inclusion of a parent node along with the
+inclusion of all of that node's children since the parent node can be
+reconstructed from the children.
+
+> This validity condition is to protect against malicious or erroneous bloating
+of proof payloads and to ensure that verification of proofs can be done in a
+single pass.
 
 
 #### Account Trie Node
@@ -153,7 +173,7 @@ content_key            := selector + SSZ.serialize(account_trie_node_key)
 content_id             := sha256(content_key)
 ```
 
-#### Contract Trie Node *
+#### Contract Trie Node
 
 
 ```
@@ -167,7 +187,7 @@ content_id             :=  sha256(content_key)
 ```
 
 
-#### Contract Code *
+#### Contract Code
 
 > NOTE: Because CREATE2 opcode allows for redeployment of new code at an existing address, we MUST randomly distribute contract code storage across the DHT keyspace to avoid hotspots developing in the network for any contract that has had many different code deployments.  Were we to use the path based *high-bits* approach for computing the content-id, it would be possible for a single location in the network to accumulate a large number of contract code objects that all live in roughly the same space.
 Problematic!


### PR DESCRIPTION
# Development branch for (WIP) updates to State Network specs:

### Change `state_network` **data types**:

 - ~`account_trie_proof`~
   - deleted*
 - ~`contract_storage_trie_proof`~
   - deleted*
 - `account_trie_node`
   - new*
 - `contract_trie_node`
   - new*
 - `contract_bytecode`
   - modified*

### Separate **content types** for *OFFERS* and *REQUESTS*:
 - **REQUEST** (*find_content*)
   - `Trie Node`
 - **OFFER**
   - `Trie Node` + `Proof`

### Distance Formula
 - ...
### Content Keys
 - ...
### Functions
 - ...
### Type Definitions
 - ...