### PR TITLE
docs: define testnet protocol identifier

### DIFF
--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -16,7 +16,8 @@ Unsupported messages **SHOULD** receive a `TALKRESP` message with an empty paylo
 
 All protocol identifiers consist of two bytes. The first byte is "`P`" (`0x50`), to indicate "the Portal network", the second byte is a specific network identifier.
 
-Currently defined protocol identifiers:
+### Mainnet identifiers
+Currently defined mainnet protocol identifiers:
 - Inclusive range of `0x5000` - `0x5009`: Reserved for future networks or network upgrades
 - `0x500A`: Execution State Network
 - `0x500B`: Execution History Network
@@ -24,6 +25,14 @@ Currently defined protocol identifiers:
 - `0x500D`: Execution Canonical Transaction Index Network
 - `0x500E`: Execution Verkle State Network
 - `0x500F`: Execution Transaction Gossip Network
+### Testnet identifiers
+Currently defined testnet protocol identifiers:
+- `0x504A`: Execution State Network
+- `0x504B`: Execution History Network
+- `0x504C`: Beacon Chain Light Client Network
+- `0x504D`: Execution Canonical Transaction Index Network
+- `0x504E`: Execution Verkle State Network
+- `0x504F`: Execution Transaction Gossip Network
 
 ## Content Keys and Content IDs
 


### PR DESCRIPTION
We are approaching launching a pre-merge history mainnet for serving 4444's data.

With the idea of mainnet in mind that means distinguishing a test network for testing major features to protect against breakages on mainnet. Or for testing future networks like beacon and state which would now take the place on the testnet work.

To distinguish these networks we will use different discv5 talkreq protocol id's.

Currently we have mainnet running history and beacon, testing if we can propagate new blocks in a timely matter. But we currently don't have validation for the post-merge data.

The mainnet's purpose would only support strict validation of data. Unlike the flexibility a testnet provides where we don't require stringent rules. So we would move the testing of beacon to our testnet.

We would only officially run history pre-merge data on mainnet as it is currently the only network which has the gears in place for this process to begin.