### PR TITLE
Create State specific JSON api-s

### DIFF
--- a/jsonrpc/.gitignore
+++ b/jsonrpc/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+
+openrpc.json

--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -72,5 +72,45 @@
     "schema": {
       "$ref": "#/components/schemas/DataRadius"
     }
+  },
+  "Address": {
+    "name": "address",
+    "description": "The address of the account",
+    "required": true,
+    "schema": {
+      "$ref": "#/components/schemas/bytes20"
+    }
+  },
+  "StateRoot": {
+    "name": "stateRoot",
+    "description": "The root of the state trie",
+    "required": true,
+    "schema": {
+      "$ref": "#/components/schemas/bytes32"
+    }
+  },
+  "Codehash": {
+    "name": "codehash",
+    "description": "The hash of the contract's code.",
+    "required": true,
+    "schema": {
+      "$ref": "#/components/schemas/bytes32"
+    }
+  },
+  "StorageRoot": {
+    "name": "storageRoot",
+    "description": "The root of the contract's storage trie",
+    "required": true,
+    "schema": {
+      "$ref": "#/components/schemas/bytes32"
+    }
+  },
+  "StorageSlot": {
+    "name": "storageSlot",
+    "description": "The slot in the storage trie",
+    "required": true,
+    "schema": {
+      "$ref": "#/components/schemas/uint256"
+    }
   }
 }

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -217,5 +217,76 @@
       "title": "number of peers",
       "type": "number"
     }
+  },
+  "DataRadiusResult": {
+    "name": "radiusResult",
+    "description": "The radius of the local node.",
+    "schema": {
+      "$ref": "#/components/schemas/DataRadius"
+    }
+  },
+  "AccountStateResult": {
+    "name": "accountStateResult",
+    "description": "The state of the account.",
+    "schema": {
+      "type": "object",
+      "required": [
+        "nonce",
+        "balance",
+        "storageRoot",
+        "codehash",
+        "proof"
+      ],
+      "properties": {
+        "nonce": {
+          "description": "The account's nonce",
+          "$ref": "#/components/schemas/uint"
+        },
+        "balance": {
+          "description": "The account's balance",
+          "$ref": "#/components/schemas/uint256"
+        },
+        "storageRoot": {
+          "description": "The root of the storate trie of the smart contract",
+          "$ref": "#/components/schemas/bytes32"
+        },
+        "codehash": {
+          "description": "The hash of the smart contract's code",
+          "$ref": "#/components/schemas/bytes32"
+        },
+        "proof": {
+          "description": "The proof of the account state inclusion",
+          "$ref": "#/components/schemas/trieProof"
+        }
+      }
+    }
+  },
+  "ContractStorageAtResult": {
+    "name": "contractStorageAtResult",
+    "description": "The value that is stored in the contract's storage trie.",
+    "schema": {
+      "type": "object",
+      "required": [
+        "value",
+        "proof"
+      ],
+      "properties": {
+        "value": {
+          "description": "The value stored in the storage trie, or \"0x0\" if missing",
+          "$ref": "#/components/schemas/uint256"
+        },
+        "proof": {
+          "description": "The proof of the inclusion",
+          "$ref": "#/components/schemas/trieProof"
+        }
+      }
+    }
+  },
+  "ContractBytecodeResult": {
+    "name": "contractBytecodeResult",
+    "description": "The contract's bytecode",
+    "schema": {
+      "$ref": "#/components/schemas/hexString"
+    }
   }
 }

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -152,6 +152,14 @@
     }
   },
   {
+    "name": "portal_historyRadius",
+    "summary": "Returns the radius used by the history network.",
+    "params": [],
+    "result": {
+      "$ref": "#/components/contentDescriptors/DataRadiusResult"
+    }
+  },
+  {
     "name": "portal_historyStore",
     "summary": "Store history content key with content data",
     "params": [

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -140,6 +140,26 @@
     }
   },
   {
+    "name": "portal_stateTraceRecursiveFindContent",
+    "summary": "Look up a target content key in the network and get tracing data",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/TraceRecursiveFindContentResult"
+    }
+  },
+  {
+    "name": "portal_stateRadius",
+    "summary": "Returns the radius used by the state network.",
+    "params": [],
+    "result": {
+      "$ref": "#/components/contentDescriptors/DataRadiusResult"
+    }
+  },
+  {
     "name": "portal_stateStore",
     "summary": "Store state content key with content data",
     "params": [
@@ -179,6 +199,54 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
+    }
+  },
+  {
+    "name": "portal_stateRecursiveFindAccountState",
+    "summary": "Traverses the state trie and returns the AccountState and its proof.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/StateRoot"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/Address"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/AccountStateResult"
+    }
+  },
+  {
+    "name": "portal_stateRecursiveFindContractStorageAt",
+    "summary": "Traverses the contract's storage trie and returns value stored at the requested slot.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Address"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/StorageRoot"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/StorageSlot"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/ContractStorageAtResult"
+    }
+  },
+  {
+    "name": "portal_stateRecursiveFindContractBytecode",
+    "summary": "Returns the contracts's bytecode.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/Address"
+      },
+      {
+        "$ref": "#/components/contentDescriptors/Codehash"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/ContractBytecodeResult"
     }
   }
 ]

--- a/jsonrpc/src/schemas/base_types.json
+++ b/jsonrpc/src/schemas/base_types.json
@@ -19,6 +19,11 @@
     "type": "string",
     "pattern": "^0x[0-9a-f]{32}$"
   },
+  "bytes20": {
+    "title": "20 hex encoded bytes",
+    "type": "string",
+    "pattern": "^0x[0-9a-f]{40}$"
+  },
   "bytes32": {
     "title": "32 hex encoded bytes",
     "type": "string",

--- a/jsonrpc/src/schemas/portal.json
+++ b/jsonrpc/src/schemas/portal.json
@@ -38,5 +38,12 @@
     "title": "UDP port number",
     "type": "string",
     "pattern": "^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
+  },
+  "trieProof": {
+    "title": "The proof of a trie node inclusion given as a list of encoded trie nodes, from the root to the target node.",
+    "type": "array",
+    "items": {
+      "$ref": "#/components/schemas/hexString"
+    }
   }
 }


### PR DESCRIPTION
Add state specific JSON api-s:

- `portal_stateRecursiveFindAccountState`
    - for a given state root and address, returns account state and proof
- `portal_stateRecursiveFindContractStorageAt`
    - for a given address, contract storage root and storage slot, returns value from the storage trie and proof
- `portal_stateRecursiveFindContractBytecode`
    - for a given address and codehash, returns contract's bytecode

This PR also defines few api-s that already exist (at least in trin):
- `portal_historyRadius`
- `portal_stateTraceRecursiveFindContent`
- `portal_stateRadius`

