### PR TITLE
Add a suggestion on how to verify recent headers

### DIFF
--- a/history/history-network.md
+++ b/history/history-network.md
@@ -381,6 +381,14 @@ The `historical_roots` is a [`BeaconState` field](https://github.com/ethereum/co
 
 The Portal network does not provide a mechanism to acquire the `historical_roots` over the network. Clients are encouraged to solve this however they choose, with the suggestion that they can include a frozen copy of the `historical_roots` within their client code, and provide a mechanism for users to override this value if they choose so.
 
+The relationship of the beacon chain structures that are used for the `BlockProofHistoricalRoots` can be seen below:
+```mermaid
+flowchart LR
+    BeaconBlock -- contains --> BeaconBlockBody -- contains --> ExecutionPayload -- contains --> block_hash
+    HistoricalBatch -- hash_tree_root--> historical_roots
+    BeaconBlock -- hash_tree_root --> HistoricalBatch
+```
+
 The first proof, the `BeaconBlockProofHistoricalRoots`, is to prove that the `BeaconBlock` is part of the `historical_roots` and thus part of the canonical chain.
 
 In order to verify this proof, the `BeaconBlock` root from the container is provided as leaf and the matching historical root is provided as root. The matching historical root index can be calculated from the slot that is provided and the index can then be used to lookup the root from the `historical_roots`.
@@ -388,3 +396,19 @@ In order to verify this proof, the `BeaconBlock` root from the container is prov
 The second proof, the `ExecutionBlockProof`, is to prove that the EL block hash is part of the `BeaconBlock`.
 
 In order to verify this part of the proof, the EL block hash is provided as leaf and the `BeaconBlock` root as root.
+
+Relationship of proof building can be seen here:
+```mermaid
+flowchart LR
+    BeaconBlock -- build_proof --> ExecutionBlockProof
+    HistoricalBatch -- build_proof --> BeaconBlockProofHistoricalRoots
+```
+
+And the verification path:
+```mermaid
+flowchart LR
+    BeaconBlockProofHistoricalRoots --> Proof1([verify_merkle_multiproof])
+    root(selected historical root) --> Proof1 --> beaconBlockRoot
+    ExecutionBlockProof --> Proof2([verify_merkle_multiproof])
+    beaconBlockRoot --> Proof2 --> block_hash
+```

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -168,9 +168,9 @@ BeaconBlockProofHistoricalRoots = Vector[Bytes32, 14]
 # Proof for EL BlockHeader from TheMerge until Capella
 BlockProofHistoricalRoots = Container[
     beaconBlockProof: BeaconBlockProofHistoricalRoots, # Proof that the BeaconBlock is part of the historical_roots and thus part of the canonical chain
-    beaconBlockRoot: Bytes32,
+    beaconBlockRoot: Bytes32, # hash_tree_root of BeaconBlock used to verify the proofs
     executionBlockProof: ExecutionBlockProof, # Proof that EL BlockHash is part of the BeaconBlock
-    slot: Slot
+    slot: Slot # Slot of BeaconBlock, used to calculate the historical_roots index
 ]
 
 BlockHeaderProof = Union[None, BlockProofHistoricalHashesAccumulator, BlockProofHistoricalRoots]
@@ -373,7 +373,7 @@ The `BlockProofHistoricalRoots` is an SSZ container which holds two Merkle proof
 - `BeaconBlockProofHistoricalRoots`
 - `ExecutionBlockProof`
 
-Additionally the SSZ container holds a `BeaconBlock` root and a slot.
+Additionally the SSZ container holds a `BeaconBlock` hash_tree_root and a slot.
 
 The chain of the two proofs allows for verifying that an EL `BlockHeader` is part of the canonical chain.
 The only requirement is having access to the beacon chain `historical_roots`.

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -202,7 +202,9 @@ as there is the `BlockProofHistoricalHashesAccumulator` solution available.
 For post-merge until Capella headers, clients SHOULD NOT accept headers without a proof as there is the `BlockProofHistoricalRoots` solution available.
 For Capella and onwards headers, clients SHOULD NOT accept headers without a proof as there is the `BlockProofHistoricalSummaries` solution available.
 For headers that are not yet part of the last period, clients SHOULD
-accept headers without a proof.
+accept headers without a proof. These headers MAY be verified if the node is following Portal beacon light client updates by verifying the `ExecutionPayloadHeader.block_hash` of the relevant `LightClientHeader`.
+
+Clients SHOULD have a way of keeping track of the recent headers that it has stored without a proof (`None`). When these headers get added in the `historical_summaries` at the end of a period, they will be re-gossiped with their proofs. Clients SHOULD accept these headers with their proof and discard the old headers without proof.
 
 ##### Block Header by Hash
 

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -369,9 +369,22 @@ As the `HistoricalHashesAccumulator` only accounts for blocks pre-merge, this pr
 
 #### BlockProofHistoricalRoots
 
-The `BlockProofHistoricalRoots` is an SSZ container which holds two Merkle proofs as specified in the [SSZ Merke proofs specification](https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs).
+The `BlockProofHistoricalRoots` is an SSZ container which holds two Merkle proofs as specified in the [SSZ Merke proofs specification](https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs):
+- `BeaconBlockProofHistoricalRoots`
+- `ExecutionBlockProof`
 
-The container holds a chain of 2 proofs. This chain of proofs allows for verifying that an EL `BlockHeader` is part of the canonical chain. The only requirement is having access to the beacon chain `historical_roots`.
-The `historical_roots` is a [`BeaconState` field](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#beaconstate) that is frozen since the Capella fork. The `HistoricalRootsBlockProof` MUST be used to verify blocks from TheMerge/Paris until the Capella fork.
+Additionally the SSZ container holds a `BeaconBlock` root and a slot.
+
+The chain of the two proofs allows for verifying that an EL `BlockHeader` is part of the canonical chain.
+The only requirement is having access to the beacon chain `historical_roots`.
+The `historical_roots` is a [`BeaconState` field](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#beaconstate) that is frozen since the Capella fork. The `BlockProofHistoricalRoots` MUST be used to verify blocks from TheMerge/Paris until the Capella fork.
 
 The Portal network does not provide a mechanism to acquire the `historical_roots` over the network. Clients are encouraged to solve this however they choose, with the suggestion that they can include a frozen copy of the `historical_roots` within their client code, and provide a mechanism for users to override this value if they choose so.
+
+The first proof, the `BeaconBlockProofHistoricalRoots`, is to prove that the `BeaconBlock` is part of the `historical_roots` and thus part of the canonical chain.
+
+In order to verify this proof, the `BeaconBlock` root from the container is provided as leaf and the matching historical root is provided as root. The matching historical root index can be calculated from the slot that is provided and the index can then be used to lookup the root from the `historical_roots`.
+
+The second proof, the `ExecutionBlockProof`, is to prove that the EL block hash is part of the `BeaconBlock`.
+
+In order to verify this part of the proof, the EL block hash is provided as leaf and the `BeaconBlock` root as root.


### PR DESCRIPTION
Adds the suggestion the verify recent headers (not yet part of the historical_summaries) by using the LightClientHeader data of the Portal beacon network (requires light client sync).

This does not resolve the issue when a node just gets started and needs to verify backtracking headers (headers between head of chain and the last header of the last period). In theory this could be resolved by doing a backwards sync of the headers, but it is probably not even an issue for the network in the first place?