### PR TITLE
Update mainnet protocol ids to be aligned

### DIFF
--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -20,9 +20,10 @@ Currently defined protocol identifiers:
 - Inclusive range of `0x5000` - `0x5009`: Reserved for future networks or network upgrades
 - `0x500A`: Execution State Network
 - `0x500B`: Execution History Network
-- `0x500C`: Execution Transaction Gossip Network
+- `0x500C`: Beacon Chain Light Client Network
 - `0x500D`: Execution Canonical Transaction Index Network
-- `0x501A`: Beacon Chain Light Client Network
+- `0x500E`: Execution Verkle State Network
+- `0x500F`: Execution Transaction Gossip Network
 
 ## Content Keys and Content IDs
 


### PR DESCRIPTION
https://github.com/ethereum/portal-network-specs/pull/258#issuecomment-2112683906

^ 
relates to this PR https://github.com/ethereum/portal-network-specs/pull/258

Having all current* network protocol ids be aligned looks nice


Kim said he likes beacon as C, I am fine with C or F.

ping @morph-dev for review too