### PR TITLE
Remove ByteList alias and fix Nodes reply to 1 response max

### DIFF
--- a/history/history-network.md
+++ b/history/history-network.md
@@ -169,7 +169,7 @@ PreMergeAccumulatorProof = Vector[Bytes32, 15]
 BlockHeaderProof = Union[None, PreMergeAccumulatorProof]
 
 BlockHeaderWithProof = Container[
-  header: ByteList, # RLP encoded header in SSZ ByteList
+  header: ByteList[2048], # RLP encoded header in SSZ ByteList
   proof: BlockHeaderProof
 ]
 ```
@@ -209,16 +209,16 @@ block_body_key          = Container(block_hash: Bytes32)
 selector                = 0x01
 
 all_transactions        = SSZList(ssz_transaction, max_length=MAX_TRANSACTION_COUNT)
-ssz_transaction         = SSZList(encoded_transaction: ByteList, max_length=MAX_TRANSACTION_LENGTH)
+ssz_transaction         = SSZList(encoded_transaction: ByteList[2048], max_length=MAX_TRANSACTION_LENGTH)
 encoded_transaction     =
   if transaction.is_typed:
     return transaction.type_byte + rlp.encode(transaction)
   else:
     return rlp.encode(transaction)
-ssz_uncles              = SSZList(encoded_uncles: ByteList, max_length=MAX_ENCODED_UNCLES_LENGTH)
+ssz_uncles              = SSZList(encoded_uncles: ByteList[2048], max_length=MAX_ENCODED_UNCLES_LENGTH)
 encoded_uncles          = rlp.encode(list_of_uncle_headers)
 all_withdrawals         = SSZList(ssz_withdrawal, max_length=MAX_WITHDRAWAL_COUNT)
-ssz_withdrawal          = SSZList(encoded_withdrawal: ByteList, max_length=MAX_WITHDRAWAL_LENGTH)
+ssz_withdrawal          = SSZList(encoded_withdrawal: ByteList[[2048], max_length=MAX_WITHDRAWAL_LENGTH)
 encoded_withdrawal      = rlp.encode(withdrawal)
 
 pre-shanghai content    = Container(all_transactions: SSZList(...), ssz_uncles: SSZList(...))
@@ -237,7 +237,7 @@ Note 2: The `list_of_uncle_headers` refers to the array of uncle headers [define
 receipt_key         = Container(block_hash: Bytes32)
 selector            = 0x02
 
-ssz_receipt         = SSZList(encoded_receipt: ByteList, max_length=MAX_RECEIPT_LENGTH)
+ssz_receipt         = SSZList(encoded_receipt: ByteList[2048], max_length=MAX_RECEIPT_LENGTH)
 encoded_receipt     =
   if receipt.is_typed:
     return type_byte + rlp.encode(receipt)

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -76,11 +76,6 @@ The type values for the `Union` are the SSZ Containers specified per message typ
 
 The transmission of `content` data that is too large to fit a single packet is done over [uTP](./discv5-utp.md).
 
-### Aliases
-
-For convenience we alias:
-- `ByteList` to `List[uint8, max_length=2048]`
-
 ### Message Types
 
 #### Ping (0x00)
@@ -89,7 +84,7 @@ Request message to check if a node is reachable, communicate basic information a
 
 ```
 selector     = 0x00
-ping         = Container(enr_seq: uint64, custom_payload: ByteList)
+ping         = Container(enr_seq: uint64, custom_payload: ByteList[2048])
 ```
 
 * `enr_seq`: The node's current sequence number of their ENR record.
@@ -101,7 +96,7 @@ Response message to Ping(0x00)
 
 ```
 selector     = 0x01
-pong         = Container(enr_seq: uint64, custom_payload: ByteList)
+pong         = Container(enr_seq: uint64, custom_payload: ByteList[2048])
 ```
 
 * `enr_seq`: The node's current sequence number of their ENR record.
@@ -126,16 +121,14 @@ Response message to FindNodes(0x02).
 
 ```
 selector     = 0x03
-nodes        = Container(total: uint8, enrs: List[ByteList, max_length=32])
+nodes        = Container(total: uint8, enrs: List[ByteList[2048], max_length=32])
 ```
 
-* `total`: The total number of `Nodes` response messages being sent.
+* `total`: The total number of `Nodes` response messages being sent. Currently fixed to only 1 response message.
 * `enrs`: List of byte strings, each of which is an RLP encoded ENR record.
     * Individual ENR records **MUST** correspond to one of the requested distances.
     * It is invalid to return multiple ENR records for the same `node_id`.
     * The ENR record of the requesting node **SHOULD** be filtered out of the list.
-
-> Note: If the number of ENR records cannot be encoded into a single message, then they should be sent back using multiple messages, with the `total` field representing the total number of messages that are being sent.
 
 #### Find Content (0x04)
 
@@ -143,7 +136,7 @@ Request message to get the `content` with `content_key`, **or**, in case the rec
 
 ```
 selector     = 0x04
-find_content = Container(content_key: ByteList)
+find_content = Container(content_key: ByteList[2048])
 ```
 
 * `content_key`: The key for the content being requested. The encoding of `content_key` is specified per the network.
@@ -157,7 +150,7 @@ requested content.
 
 ```
 selector     = 0x05
-content      = Union[connection_id: Bytes2, content: ByteList, enrs: List[ByteList, 32]]
+content      = Union[connection_id: Bytes2, content: ByteList[2048], enrs: List[ByteList[2048], 32]]
 ```
 
 * `connection_id`: Connection ID to set up a uTP stream to transmit the requested data.
@@ -188,13 +181,13 @@ ssz-type = Bytes2
 **`content`**
 ```
 selector = 0x01
-ssz-type = ByteList
+ssz-type = ByteList[2048]
 ```
 
 **`enrs`**
 ```
 selector = 0x02
-ssz-type = List[ByteList, 32]
+ssz-type = List[ByteList[2048], 32]
 ```
 
 #### Offer (0x06)
@@ -203,7 +196,7 @@ Request message to offer a set of `content_keys` that this node has `content` av
 
 ```
 selector     = 0x06
-offer        = Container(content_keys: List[ByteList, max_length=64])
+offer        = Container(content_keys: List[ByteList[2048], max_length=64])
 ```
 
 * `content_keys`: A list of encoded `content_key` entries. The encoding of each `content_key` is specified per the network.

--- a/transaction-gossip/transaction-gossip.md
+++ b/transaction-gossip/transaction-gossip.md
@@ -53,7 +53,7 @@ content_id   := transaction_hash
 The data payload for a transaction comes with an merkle proof of the `transaction.to` account.
 
 ```
-payload     := Container(proof: Proof, transaction: ByteList)
+payload     := Container(proof: Proof, transaction: ByteList[2048])
 proof       := TODO
 transaction := TODO
 ```


### PR DESCRIPTION
This doesn't really change anything to what the clients currently have implemented.

Might want to review in the future some of the sizes of the ByteLists used but for now no functional change on this.