### PR TITLE
Use the same SSZ types & names as defined in SSZ spec

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -167,7 +167,7 @@ content_key                = selector + SSZ.serialize(light_client_bootstrap_key
 light_client_update_keys   = Container(start_period: uint64, count: uint64)
 selector                   = 0x11
 
-content                    = SSZList(ForkDigest + LightClientUpdate, max_lenght=MAX_REQUEST_LIGHT_CLIENT_UPDATES)
+content                    = List(ForkDigest + LightClientUpdate, limit=MAX_REQUEST_LIGHT_CLIENT_UPDATES)
 content_key                = selector + SSZ.serialize(light_client_update_keys)
 ```
 
@@ -222,7 +222,7 @@ historical_summaries_with_proof = HistoricalSummariesWithProof(
     epoch: uint64,
     # HistoricalSummary object is defined in consensus specs:
     # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
-    historical_summaries: SSZList(HistoricalSummary, max_length=HISTORICAL_ROOTS_LIMIT),
+    historical_summaries: List(HistoricalSummary, limit=HISTORICAL_ROOTS_LIMIT),
     proof: HistoricalSummariesProof
 )
 

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -209,21 +209,21 @@ the following sequence to decode & validate block bodies.
 block_body_key          = Container(block_hash: Bytes32)
 selector                = 0x01
 
-all_transactions        = SSZList(ssz_transaction, max_length=MAX_TRANSACTION_COUNT)
-ssz_transaction         = SSZList(encoded_transaction: ByteList[2048], max_length=MAX_TRANSACTION_LENGTH)
+all_transactions        = List(ssz_transaction, limit=MAX_TRANSACTION_COUNT)
+ssz_transaction         = List(encoded_transaction: ByteList[2048], limit=MAX_TRANSACTION_LENGTH)
 encoded_transaction     =
   if transaction.is_typed:
     return transaction.type_byte + rlp.encode(transaction)
   else:
     return rlp.encode(transaction)
-ssz_uncles              = SSZList(encoded_uncles: ByteList[2048], max_length=MAX_ENCODED_UNCLES_LENGTH)
+ssz_uncles              = List(encoded_uncles: ByteList[2048], limit=MAX_ENCODED_UNCLES_LENGTH)
 encoded_uncles          = rlp.encode(list_of_uncle_headers)
-all_withdrawals         = SSZList(ssz_withdrawal, max_length=MAX_WITHDRAWAL_COUNT)
-ssz_withdrawal          = SSZList(encoded_withdrawal: ByteList[[2048], max_length=MAX_WITHDRAWAL_LENGTH)
+all_withdrawals         = List(ssz_withdrawal, limit=MAX_WITHDRAWAL_COUNT)
+ssz_withdrawal          = List(encoded_withdrawal: ByteList[[2048], limit=MAX_WITHDRAWAL_LENGTH)
 encoded_withdrawal      = rlp.encode(withdrawal)
 
-pre-shanghai content    = Container(all_transactions: SSZList(...), ssz_uncles: SSZList(...))
-post-shanghai content   = Container(all_transactions: SSZList(...), ssz_uncles: SSZList(encoded_uncles), all_withdrawals: SSZList(...))
+pre-shanghai content    = Container(all_transactions: List(...), ssz_uncles: List(...))
+post-shanghai content   = Container(all_transactions: List(...), ssz_uncles: List(encoded_uncles), all_withdrawals: List(...))
 content_key             = selector + SSZ.serialize(block_body_key)
 ```
 
@@ -238,14 +238,14 @@ Note 2: The `list_of_uncle_headers` refers to the array of uncle headers [define
 receipt_key         = Container(block_hash: Bytes32)
 selector            = 0x02
 
-ssz_receipt         = SSZList(encoded_receipt: ByteList[2048], max_length=MAX_RECEIPT_LENGTH)
+ssz_receipt         = List(encoded_receipt: ByteList[2048], limit=MAX_RECEIPT_LENGTH)
 encoded_receipt     =
   if receipt.is_typed:
     return type_byte + rlp.encode(receipt)
   else:
     return rlp.encode(receipt)
 
-content             = SSZList(ssz_receipt, max_length=MAX_TRANSACTION_COUNT)
+content             = List(ssz_receipt, limit=MAX_TRANSACTION_COUNT)
 content_key         = selector + SSZ.serialize(receipt_key)
 ```
 
@@ -278,13 +278,13 @@ EPOCH_SIZE = 8192 # blocks
 MAX_HISTORICAL_EPOCHS = 2048
 
 # An individual record for a historical header.
-HeaderRecord = Container[block_hash: bytes32, total_difficulty: uint256]
+HeaderRecord = Container[block_hash: Bytes32, total_difficulty: uint256]
 
 # The records of the headers from within a single epoch
-EpochRecord = List[HeaderRecord, max_length=EPOCH_SIZE]
+EpochRecord = List[HeaderRecord, limit=EPOCH_SIZE]
 
 HistoricalHashesAccumulator = Container[
-    historical_epochs: List[bytes32, max_length=MAX_HISTORICAL_EPOCHS],
+    historical_epochs: List[Bytes32, limit=MAX_HISTORICAL_EPOCHS],
     current_epoch: EpochRecord,
 ]
 ```

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -108,7 +108,7 @@ Request message to get ENR records from the recipient's routing table at the giv
 
 ```
 selector     = 0x02
-find_nodes   = Container(distances: List[uint16, max_length=256])
+find_nodes   = Container(distances: List[uint16, limit=256])
 ```
 
 * `distances`: a list of distances for which the node is requesting ENR records for.
@@ -121,7 +121,7 @@ Response message to FindNodes(0x02).
 
 ```
 selector     = 0x03
-nodes        = Container(total: uint8, enrs: List[ByteList[2048], max_length=32])
+nodes        = Container(total: uint8, enrs: List[ByteList[2048], limit=32])
 ```
 
 * `total`: The total number of `Nodes` response messages being sent. Currently fixed to only 1 response message.
@@ -196,7 +196,7 @@ Request message to offer a set of `content_keys` that this node has `content` av
 
 ```
 selector     = 0x06
-offer        = Container(content_keys: List[ByteList[2048], max_length=64])
+offer        = Container(content_keys: List[ByteList[2048], limit=64])
 ```
 
 * `content_keys`: A list of encoded `content_key` entries. The encoding of each `content_key` is specified per the network.
@@ -209,7 +209,7 @@ Signals interest in receiving the offered data from the corresponding Offer mess
 
 ```
 selector     = 0x07
-accept       = Container(connection_id: Bytes2, content_keys: BitList[max_length=64]]
+accept       = Container(connection_id: Bytes2, content_keys: BitList[limit=64]]
 ```
 
 * `connection_id`: Connection ID to set up a uTP stream to transmit the requested data.

--- a/state/state-network.md
+++ b/state/state-network.md
@@ -143,7 +143,7 @@ store it and it can't be part of the trie proof.
 
 ```
 TrieNode   := ByteList(1024)
-TrieProof  := List(TrieNode, max_length=65)
+TrieProof  := List(TrieNode, limit=65)
 ```
 
 The `TrieProof` type is used for both Account Trie and Contract Storage trie.


### PR DESCRIPTION
A few renames to be consistent with consensus SSZ specs and also to be consistent within the different Portal network specifications.