### PR TITLE
feat(json-rpc): add `portal_beaconFinalizedStateRoot` JSON-RPC endpoint

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -14,6 +14,14 @@
       "$ref": "#/components/schemas/bytes32"
     }
   },
+  "BeaconFinalizedStateRootResult": {
+    "name": "finalizedStateRootResult",
+    "description": "Returns the hex encoded finalized beacon state root.",
+    "schema": {
+      "title": "Hex encoded finalized beacon state root",
+      "$ref": "#/components/schemas/bytes32"
+    }
+  },
   "StoreResult": {
     "name": "storeResult",
     "description": "Returns \"true\" upon success",

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -68,6 +68,14 @@
     }
   },
   {
+    "name": "portal_beaconFinalizedStateRoot",
+    "summary": "Get latest known finalized beacon state root.",
+    "params": [],
+    "result": {
+      "$ref": "#/components/contentDescriptors/BeaconFinalizedStateRootResult"
+    }
+  },
+  {
     "name": "portal_beaconFindNodes",
     "summary": "Send a FINDNODES request for nodes that fall within the given set of distances, to the designated peer and wait for a response.",
     "params": [


### PR DESCRIPTION
A propose to add the `portal_beaconFinalizedStateRoot` endpoint to beacon JSON-RPC specs.

We already use this endpoint in Trin and it will be useful in hive when testing if a node keeps up with the finalized head.