### PR TITLE
Proposal for block header lookup via block number in the history network

### DIFF
--- a/history/history-network.md
+++ b/history/history-network.md
@@ -8,7 +8,7 @@ The chain history network is a [Kademlia](https://pdos.csail.mit.edu/~petar/pape
 
 Execution chain history data consists of historical block headers, block bodies (transactions, ommers and withdrawals) and block receipts.
 
-In addition, the chain history network provides block number to historical block header lookups
+In addition, the chain history network provides block number to historical block header lookups.
 
 ### Data
 
@@ -192,7 +192,7 @@ content_key      = selector + SSZ.serialize(block_header_key)
 # Content and content key
 
 block_number_key = Container(block_number: uint64)
-selector         = 0x04
+selector         = 0x03
 
 block_header_with_proof = BlockHeaderWithProof(header: rlp.encode(header), proof: proof)
 

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -20,7 +20,6 @@ In addition, the chain history network provides block number to historical block
     - Ommers
     - Withdrawals
 - Receipts
-- Block header indexes
 
 #### Retrieval
 
@@ -166,6 +165,14 @@ BlockHeaderWithProof = Container(
 )
 ```
 
+> **_Note:_** The `BlockHeaderProof` allows to provide headers without a proof (`None`).
+For pre-merge headers, clients SHOULD NOT accept headers without a proof
+as there is the `HistoricalHashesAccumulatorProof` solution available.
+For post-merge headers, there is currently no proof solution and clients MAY
+accept headers without a proof.
+
+##### Block Header by Hash
+
 ```python
 # Content and content key
 
@@ -178,11 +185,20 @@ content          = SSZ.serialize(block_header_with_proof)
 content_key      = selector + SSZ.serialize(block_header_key)
 ```
 
-> **_Note:_** The `BlockHeaderProof` allows to provide headers without a proof (`None`).
-For pre-merge headers, clients SHOULD NOT accept headers without a proof
-as there is the `HistoricalHashesAccumulatorProof` solution available.
-For post-merge headers, there is currently no proof solution and clients MAY
-accept headers without a proof.
+##### Block Header by Number
+
+
+```python
+# Content and content key
+
+block_number_key = Container(block_number: uint64)
+selector         = 0x04
+
+block_header_with_proof = BlockHeaderWithProof(header: rlp.encode(header), proof: proof)
+
+content          = SSZ.serialize(block_header_with_proof)
+content_key      = selector + SSZ.serialize(block_number_key)
+```
 
 #### Block Body
 
@@ -258,27 +274,6 @@ content_key         = selector + SSZ.serialize(receipt_key)
 ```
 
 Note: The type-specific receipts encoding might be different for future receipt types, but this content encoding is agnostic to the underlying receipt encodings.
-
-#### Block Header Indexes
-
-
-```python
-# Content and content key
-
-block_number_key = Container(block_number: uint64)
-selector         = 0x04
-
-block_header_with_proof = BlockHeaderWithProof(header: rlp.encode(header), proof: proof)
-
-content          = SSZ.serialize(block_header_with_proof)
-content_key      = selector + SSZ.serialize(block_number_key)
-```
-
-> **_Note:_** The `BlockHeaderProof` allows to provide headers without a proof (`None`).
-For pre-merge headers, clients SHOULD NOT accept headers without a proof
-as there is the `HistoricalHashesAccumulatorProof` solution available.
-For post-merge headers, there is currently no proof solution and clients MAY
-accept headers without a proof.
 
 ### Algorithms
 

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -26,9 +26,9 @@ In addition, the chain history network provides block number to historical block
 The network supports the following mechanisms for data retrieval:
 
 - Block header by block header hash
+- Block header by block number
 - Block body by block header hash
 - Block receipts by block header hash
-- Block header by block number
 
 > This sub-protocol does **not** support retrieval of transactions by hash, only the full set of transactions for a given block. See the "Canonical Transaction Index" sub-protocol of the Portal Network for more information on how the portal network implements lookup of transactions by their individual hashes.
 


### PR DESCRIPTION
Offshoot of this PR https://github.com/ethereum/portal-network-specs/pull/333 you can read for a deeper background or reasoning.

In the other PR I list Pro's and Con's of certain block index model's and in the end come to the conclusion that it would probably just make more sense to store these values in the History network, as the total storage size for these indexes will be around 22ish GB with proofs. Which is extremely small in comparison with the requirements to store block bodies and receipts which is around 749.94GB so I think it is well justified. 

In the same note we have previously discussed https://github.com/ethereum/portal-network-specs/pull/268 removing `epoch accumulator history network content type`, but decided not to due to not having a better solution during the time.

With this proposal we add `block number -> block header` lookup capabilities 

Here is a copy paste from my other PR why we want these indexes
- Most JSON-RPC calls support requesting data by block number
- ETH Call requires block number -> block hash indexes for the last 256 blocks (in Portal's case we would need access to all the blocks 0 to latest to properly support eth call)
- Being able to fetch header's by block number is more intuitive and easier to get what you want, our current model requires you to start from the latest block header from the beacon network and walk back to your desired block header, so potentially if you wanted the block header for block 1 you would have to fetch 20 million headers which is a little overkill

In short this proposal offers a much better UX experience and enables us to properly implement the JSON-RPC