### PR TITLE
Update `portal_*Offer` jsonrpc call to accept multiple key-value pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+jsonrpc/openrpc.json
+jsonrpc/node_modules

--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -43,6 +43,17 @@
       }
     }
   },
+  "ContentPairs": {
+    "name": "content_pairs",
+    "required": true,
+    "schema": {
+      "title": "content_pair",
+      "type": "array",
+      "items": {
+            "$ref": "#/components/schemas/ContentPair"
+      }
+    }
+  },   
   "Enr": {
     "name": "enr",
     "required": true,

--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -43,14 +43,14 @@
       }
     }
   },
-  "ContentPairs": {
-    "name": "content_pairs",
+  "ContentItems": {
+    "name": "content_items",
     "required": true,
     "schema": {
-      "title": "content_pair",
+      "title": "content_item",
       "type": "array",
       "items": {
-            "$ref": "#/components/schemas/ContentPair"
+        "$ref": "#/components/schemas/ContentItem"
       }
     }
   },   

--- a/jsonrpc/src/content/params.json
+++ b/jsonrpc/src/content/params.json
@@ -51,7 +51,9 @@
       "type": "array",
       "items": {
         "$ref": "#/components/schemas/ContentItem"
-      }
+      },
+      "minItems": 1,
+      "maxItems": 64
     }
   },   
   "Enr": {

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "portal_beaconOffer",
-    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided..",
+    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -99,13 +99,13 @@
   },
   {
     "name": "portal_beaconOffer",
-    "summary": "Send an OFFER request with given array of Content Pairs (Keys & Values), to the designated peer and wait for a response. `portal_historyOffer` should only accept 1 to 64 content pairs else the client will throw an out of bounds error.",
+    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided..",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentPairs"
+        "$ref": "#/components/contentDescriptors/ContentItems"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -105,10 +105,7 @@
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentValue"
+        "$ref": "#/components/contentDescriptors/ContentPairs"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "portal_beaconOffer",
-    "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
+    "summary": "Send an OFFER request with given array of Content Pairs (Keys & Values), to the designated peer and wait for a response. `portal_historyOffer` should only accept 1 to 64 content pairs else the client will throw an out of bounds error.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "portal_historyOffer",
-    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided..",
+    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -105,10 +105,7 @@
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentValue"
+        "$ref": "#/components/contentDescriptors/ContentPairs"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -99,13 +99,13 @@
   },
   {
     "name": "portal_historyOffer",
-    "summary": "Send an OFFER request with given array of Content Pairs (Keys & Values), to the designated peer and wait for a response. `portal_historyOffer` should only accept 1 to 64 content pairs else the client will throw an out of bounds error.",
+    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided..",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentPairs"
+        "$ref": "#/components/contentDescriptors/ContentItems"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "portal_historyOffer",
-    "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
+    "summary": "Send an OFFER request with given array of Content Pairs (Keys & Values), to the designated peer and wait for a response. `portal_historyOffer` should only accept 1 to 64 content pairs else the client will throw an out of bounds error.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "portal_stateOffer",
-    "summary": "Send an OFFER request with given ContentKey, to the designated peer and wait for a response.",
+    "summary": "Send an OFFER request with given array of Content Pairs (Keys & Values), to the designated peer and wait for a response. `portal_historyOffer` should only accept 1 to 64 content pairs else the client will throw an out of bounds error.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -105,10 +105,7 @@
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      },
-      {
-        "$ref": "#/components/contentDescriptors/ContentValue"
+        "$ref": "#/components/contentDescriptors/ContentPairs"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -99,13 +99,13 @@
   },
   {
     "name": "portal_stateOffer",
-    "summary": "Send an OFFER request with given array of Content Pairs (Keys & Values), to the designated peer and wait for a response. `portal_historyOffer` should only accept 1 to 64 content pairs else the client will throw an out of bounds error.",
+    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided..",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"
       },
       {
-        "$ref": "#/components/contentDescriptors/ContentPairs"
+        "$ref": "#/components/contentDescriptors/ContentItems"
       }
     ],
     "result": {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "portal_stateOffer",
-    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided..",
+    "summary": "Send an OFFER request with given array of content items (keys & values), to the designated peer and wait for a response. The client MUST return an error if more than 64 content items are provided or less than 1 content items are provided.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/Enr"

--- a/jsonrpc/src/schemas/portal.json
+++ b/jsonrpc/src/schemas/portal.json
@@ -46,12 +46,12 @@
       {
         "title": "Content key",
         "description": "The encoded Portal content key",
-        "$ref": "#/components/contentDescriptors/ContentKey"
+        "$ref": "#/components/schemas/hexString"
       },
       {
         "title": "Content value",
         "description": "The encoded Portal content value",
-        "$ref": "#/components/contentDescriptors/ContentValue"
+        "$ref": "#/components/schemas/hexString"
       }
     ],
     "minItems": 2,

--- a/jsonrpc/src/schemas/portal.json
+++ b/jsonrpc/src/schemas/portal.json
@@ -39,20 +39,23 @@
     "type": "string",
     "pattern": "^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
   },
-  "ContentPair": {
-    "title": "content_pair",
-    "type": "object",
-    "properties": {
-      "contentKey": {
+  "ContentItem": {
+    "title": "content_item",
+    "type": "array",
+    "items": [
+      {
         "title": "Content key",
         "description": "The encoded Portal content key",
-        "$ref": "#/components/schemas/hexString"
+        "$ref": "#/components/contentDescriptors/ContentKey"
       },
-      "contentValue": {
+      {
         "title": "Content value",
         "description": "The encoded Portal content value",
-        "$ref": "#/components/schemas/hexString"
+        "$ref": "#/components/contentDescriptors/ContentValue"
       }
-    }
+    ],
+    "minItems": 2,
+    "maxItems": 2,
+    "additionalItems": false
   }
 }

--- a/jsonrpc/src/schemas/portal.json
+++ b/jsonrpc/src/schemas/portal.json
@@ -38,5 +38,21 @@
     "title": "UDP port number",
     "type": "string",
     "pattern": "^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
+  },
+  "ContentPair": {
+    "title": "content_pair",
+    "type": "object",
+    "properties": {
+      "contentKey": {
+        "title": "Content key",
+        "description": "The encoded Portal content key",
+        "$ref": "#/components/schemas/hexString"
+      },
+      "contentValue": {
+        "title": "Content value",
+        "description": "The encoded Portal content value",
+        "$ref": "#/components/schemas/hexString"
+      }
+    }
   }
 }


### PR DESCRIPTION
I am trying to write a Hive test for https://github.com/ethereum/trin/issues/1484, and I am sending offer values of 64 items. The current issue I am facing is all Portal clients don't implement a JSON-RPC command that can send more than 1 piece of content per offer.

Trin already does, though, and we call it `portal_historyWireOffer.` I believe Nick made it for internal testing, but I think it would be useful for all clients to implement it for hive.

I am not adding this command to State or Beacon due to the way it works. If we want it to work for the State Network, we should include the content value in the parameters. I think Nick didn't do this because the message would could be very big, which might be a bad idea? I'm unsure if that is an issue, though, if the limit is only 64 items.


## Recap
It is currently not possible to test whether Portal clients follow the spec in being able to send 64 pieces of content in one offer. I am open to discussing making this an RPC call in the `debug` namespace.

# Update to PR 9/26/2024

After a suggestion from Scotty the current leading solution is to make our current `portal_*Offer` accept multiple items. I updated the PR to reflect this