### PR TITLE
Rename portal_*RecursiveFindContent to portal_*GetContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Specify filepatterns you want git to ignore.
+jsonrpc/openrpc.json
+jsonrpc/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-# Specify filepatterns you want git to ignore.
 jsonrpc/openrpc.json
 jsonrpc/node_modules

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -34,7 +34,7 @@
     "schema": {
       "title": "FindContentResult",
       "type": "object",
-      "oneOf" :[
+      "oneOf": [
         {
           "title": "ContentInfo",
           "type": "object",
@@ -58,7 +58,9 @@
           "title": "ENRs",
           "description": "List of ENR records of nodes that are closer than the recipient is to the requested content",
           "type": "object",
-          "required": ["enrs"],
+          "required": [
+            "enrs"
+          ],
           "properties": {
             "enrs": {
               "type": "array",
@@ -164,8 +166,8 @@
       }
     }
   },
-  "RecursiveFindContentResult": {
-    "name": "RecursiveFindContentResult",
+  "GetContentResult": {
+    "name": "GetContentResult",
     "description": "Returns the hex encoded content value and utp transfer flag. If the content is not available, returns \"0x\"",
     "schema": {
       "type": "object",
@@ -185,8 +187,8 @@
       }
     }
   },
-  "TraceRecursiveFindContentResult": {
-    "name": "TraceRecursiveFindContentResult",
+  "TraceGetContentResult": {
+    "name": "TraceGetContentResult",
     "description": "Returns the hex encoded content value and trace data object. If the content is not available, returns \"0x\"",
     "schema": {
       "type": "object",
@@ -224,13 +226,6 @@
     "schema": {
       "title": "number of peers",
       "type": "number"
-    }
-  },
-  "GetContentResult": {
-    "name": "GetContentResult",
-    "description": "Returns the hex encoded content value. If the content is not available, returns \"0x\"",
-    "schema": {
-      "$ref": "#/components/schemas/hexString"
     }
   }
 }

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -225,5 +225,12 @@
       "title": "number of peers",
       "type": "number"
     }
+  },
+  "GetContentResult": {
+    "name": "GetContentResult",
+    "description": "Returns the hex encoded content value. If the content is not available, returns \"0x\"",
+    "schema": {
+      "$ref": "#/components/schemas/hexString"
+    }
   }
 }

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -146,7 +146,7 @@
   },
   {
     "name": "portal_beaconTraceGetContent",
-    "summary": "Look up a target content as defined in portal_beaconGetContent and get tracing data",
+    "summary": "Get content as defined in portal_beaconGetContent and get additional tracing data",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -200,5 +200,17 @@
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
     }
+  },
+  {
+    "name": "portal_beaconGetContent",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/GetContentResult"
+    }
   }
 ]

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -133,27 +133,27 @@
     }
   },
   {
-    "name": "portal_beaconRecursiveFindContent",
-    "summary": "Look up a target content key in the network",
+    "name": "portal_beaconGetContent",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/GetContentResult"
     }
   },
   {
-    "name": "portal_beaconTraceRecursiveFindContent",
-    "summary": "Look up a target content key in the network and get tracing data",
+    "name": "portal_beaconTraceGetContent",
+    "summary": "Look up a target content as defined in portal_beaconGetContent and get tracing data",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/TraceRecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/TraceGetContentResult"
     }
   },
   {
@@ -196,18 +196,6 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
-    }
-  },
-  {
-    "name": "portal_beaconGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/GetContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "portal_beaconGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -203,7 +203,7 @@
   },
   {
     "name": "portal_beaconGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -195,7 +195,7 @@
   },
   {
     "name": "portal_historyGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -138,7 +138,7 @@
   },
   {
     "name": "portal_historyTraceGetContent",
-    "summary": "Look up a target content as defined in portal_historyGetContent and get tracing data",
+    "summary": "Get content as defined in portal_historyGetContent and get additional tracing data",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -192,5 +192,17 @@
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
     }
+  },
+  {
+    "name": "portal_historyGetContent",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/GetContentResult"
+    }
   }
 ]

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -125,27 +125,27 @@
     }
   },
   {
-    "name": "portal_historyRecursiveFindContent",
-    "summary": "Look up a target content key in the network",
+    "name": "portal_historyGetContent",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/GetContentResult"
     }
   },
   {
-    "name": "portal_historyTraceRecursiveFindContent",
-    "summary": "Look up a target content key in the network and get tracing data",
+    "name": "portal_historyTraceGetContent",
+    "summary": "Look up a target content as defined in portal_historyGetContent and get tracing data",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/TraceRecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/TraceGetContentResult"
     }
   },
   {
@@ -188,18 +188,6 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
-    }
-  },
-  {
-    "name": "portal_historyGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/GetContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "portal_historyGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -183,7 +183,7 @@
   },
   {
     "name": "portal_stateGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -125,15 +125,15 @@
     }
   },
   {
-    "name": "portal_stateRecursiveFindContent",
-    "summary": "Look up a target content key in the network",
+    "name": "portal_stateGetContent",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/RecursiveFindContentResult"
+      "$ref": "#/components/contentDescriptors/GetContentResult"
     }
   },
   {
@@ -176,18 +176,6 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
-    }
-  },
-  {
-    "name": "portal_stateGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
-    "params": [
-      {
-        "$ref": "#/components/contentDescriptors/ContentKey"
-      }
-    ],
-    "result": {
-      "$ref": "#/components/contentDescriptors/GetContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -180,5 +180,17 @@
     "result": {
       "$ref": "#/components/contentDescriptors/GossipResult"
     }
+  },
+  {
+    "name": "portal_stateGetContent",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network.",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/GetContentResult"
+    }
   }
 ]

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "portal_stateGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -134,6 +134,18 @@
     ],
     "result": {
       "$ref": "#/components/contentDescriptors/GetContentResult"
+    }
+  },
+  {
+    "name": "portal_stateTraceGetContent",
+    "summary": "Get content as defined in portal_stateGetContent and get additional tracing data",
+    "params": [
+      {
+        "$ref": "#/components/contentDescriptors/ContentKey"
+      }
+    ],
+    "result": {
+      "$ref": "#/components/contentDescriptors/TraceGetContentResult"
     }
   },
   {


### PR DESCRIPTION
I recently started working on building a portal rpc client library to be used in Nimbus to fetch the history network data, headers, bodies and receipts from portal in preparation for EIP-4444. When implementing the code I realized that as a user of the portal RPC API it would be nice to have a higher level endpoint that is able to lookup the content in the local database first before trying to fetch the content from the network. 

Without this new endpoint I had to first call `portal_historyLocalContent`, and then if a not found error was returned then call `portal_historyRecursiveFindContent` to look up the content over the network. This works but doesn't store the fetched content in the local database unless I also call `portal_historyStore` after getting the content from the network lookup. Storing the content in the local database after fetching from the network is a good idea so that a second call for the same content can simply get the data from the local database (assuming that the data is within the node's radius). 

Having to do multiple RPC calls isn't ideal and it would be helpful to have an endpoint that does the following:
1. Fetch the content from the local database and return it if it exists.
2. Otherwise fetch the content from the network using recursive find content.
3. If the content is found, validate the content before storing in the local database then return the content.

This PR introduces `portal_historyGetContent`, `portal_stateGetContent` and `portal_beaconGetContent` RPC endpoints which should behave as described above.