### PR TITLE
Rename portal_*Gossip JSON-RPC endpoint to portal_*PutContent

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -222,10 +222,23 @@
   },
   "PutContentResult": {
     "name": "PutContentResult",
-    "description": "Returns the number of peers that the content was gossiped to",
+    "description": "Returns the number of peers that the content was gossiped to and a flag indicating whether the content was stored locally or not.",
     "schema": {
-      "title": "number of peers",
-      "type": "number"
+      "type": "object",
+      "required": [
+        "peerCount",
+        "storedLocally"
+      ],
+      "properties": {
+        "peerCount": {
+          "description": "Indicates how many peers the content was gossiped to.",
+          "type": "number"
+        },
+        "storedLocally": {
+          "description": "Indicates whether the content was stored locally or not.",
+          "type": "boolean"
+        }
+      }
     }
   }
 }

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -220,8 +220,8 @@
       "$ref": "#/components/schemas/hexString"
     }
   },
-  "GossipResult": {
-    "name": "gossipResult",
+  "PutContentResult": {
+    "name": "PutContentResult",
     "description": "Returns the number of peers that the content was gossiped to",
     "schema": {
       "title": "number of peers",

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "portal_beaconGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated for correctness and stored in the local database if storage criteria is met before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -200,7 +200,7 @@
   },
   {
     "name": "portal_beaconPutContent",
-    "summary": "Validate that the content is well formed and store it in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -200,7 +200,7 @@
   },
   {
     "name": "portal_beaconPutContent",
-    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers using the client's default gossip mechanisms.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "portal_beaconGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database if storage criteria is met before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated for correctness and stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -200,7 +200,7 @@
   },
   {
     "name": "portal_beaconPutContent",
-    "summary": "Validate and store the provided content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Validate that the content is well formed and store it in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -143,9 +143,11 @@
     "result": {
       "$ref": "#/components/contentDescriptors/GetContentResult"
     },
-    "errors":[{
-      "$ref": "#/components/errors/ContentNotFoundError"
-    }]
+    "errors": [
+      {
+        "$ref": "#/components/errors/ContentNotFoundError"
+      }
+    ]
   },
   {
     "name": "portal_beaconTraceGetContent",
@@ -158,9 +160,11 @@
     "result": {
       "$ref": "#/components/contentDescriptors/TraceGetContentResult"
     },
-    "errors":[{
-      "$ref": "#/components/errors/ContentNotFoundErrorWithTrace"
-    }]
+    "errors": [
+      {
+        "$ref": "#/components/errors/ContentNotFoundErrorWithTrace"
+      }
+    ]
   },
   {
     "name": "portal_beaconStore",
@@ -188,13 +192,15 @@
     "result": {
       "$ref": "#/components/contentDescriptors/LocalContentResult"
     },
-    "errors":[{
-      "$ref": "#/components/errors/ContentNotFoundError"
-    }]
+    "errors": [
+      {
+        "$ref": "#/components/errors/ContentNotFoundError"
+      }
+    ]
   },
   {
-    "name": "portal_beaconGossip",
-    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
+    "name": "portal_beaconPutContent",
+    "summary": "Validate and store the provided content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -204,7 +210,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/GossipResult"
+      "$ref": "#/components/contentDescriptors/PutContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "portal_historyGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database if storage criteria is met before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated for correctness and stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -135,9 +135,11 @@
     "result": {
       "$ref": "#/components/contentDescriptors/GetContentResult"
     },
-    "errors":[{
-      "$ref": "#/components/errors/ContentNotFoundError"
-    }]
+    "errors": [
+      {
+        "$ref": "#/components/errors/ContentNotFoundError"
+      }
+    ]
   },
   {
     "name": "portal_historyTraceGetContent",
@@ -150,9 +152,11 @@
     "result": {
       "$ref": "#/components/contentDescriptors/TraceGetContentResult"
     },
-    "errors":[{
-      "$ref": "#/components/errors/ContentNotFoundErrorWithTrace"
-    }]
+    "errors": [
+      {
+        "$ref": "#/components/errors/ContentNotFoundErrorWithTrace"
+      }
+    ]
   },
   {
     "name": "portal_historyStore",
@@ -180,13 +184,15 @@
     "result": {
       "$ref": "#/components/contentDescriptors/LocalContentResult"
     },
-    "errors":[{
-      "$ref": "#/components/errors/ContentNotFoundError"
-    }]
+    "errors": [
+      {
+        "$ref": "#/components/errors/ContentNotFoundError"
+      }
+    ]
   },
   {
     "name": "portal_historyPutContent",
-    "summary": "Validate and store the provided content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Validate that the content is well formed and store it in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "portal_historyGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated for correctness and stored in the local database if storage criteria is met before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -192,7 +192,7 @@
   },
   {
     "name": "portal_historyPutContent",
-    "summary": "Validate that the content is well formed and store it in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -192,7 +192,7 @@
   },
   {
     "name": "portal_historyPutContent",
-    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers using the client's default gossip mechanisms.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -185,8 +185,8 @@
     }]
   },
   {
-    "name": "portal_historyGossip",
-    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
+    "name": "portal_historyPutContent",
+    "summary": "Validate and store the provided content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -196,7 +196,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/GossipResult"
+      "$ref": "#/components/contentDescriptors/PutContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "portal_stateGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated for correctness and stored in the local database if storage criteria is met before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -186,7 +186,7 @@
   },
   {
     "name": "portal_statePutContent",
-    "summary": "Validate that the content is well formed and store it in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "portal_stateGetContent",
-    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated and stored in the local database if storage criteria is met before being returned.",
+    "summary": "Get content from the local database if it exists, otherwise look up the target content key in the network. After fetching from the network the content is validated for correctness and stored in the local database if storage criteria is met before being returned.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -186,7 +186,7 @@
   },
   {
     "name": "portal_statePutContent",
-    "summary": "Validate and store the provided content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Validate that the content is well formed and store it in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -185,8 +185,8 @@
     }]
   },
   {
-    "name": "portal_stateGossip",
-    "summary": "Send the provided content item to interested peers. Clients may choose to send to some or all peers.",
+    "name": "portal_statePutContent",
+    "summary": "Validate and store the provided content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"
@@ -196,7 +196,7 @@
       }
     ],
     "result": {
-      "$ref": "#/components/contentDescriptors/GossipResult"
+      "$ref": "#/components/contentDescriptors/PutContentResult"
     }
   }
 ]

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -186,7 +186,7 @@
   },
   {
     "name": "portal_statePutContent",
-    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers. Clients may choose to send to some or all peers.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers using the client's default gossip mechanisms.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"


### PR DESCRIPTION
I suggest that we rename the `portal_*Gossip` JSON-RPC endpoint to `portal_*PutContent` and also update the method definition to include storing the content in the local database after performing some basic validations.

Changes in this PR:
- Renamed `portal_*Gossip` JSON-RPC endpoint to `portal_*PutContent`
- Updated the endpoint spec definition to include validation and storage in the local db

This is a similar update to https://github.com/ethereum/portal-network-specs/pull/344. My reasoning for this change is that I think we should have a high level endpoint counterpart to `portal_*GetContent` with similar naming and implementation storing in the local database when it makes sense to do so. 
 