### PR TITLE
Add poke to state network spec

### DIFF
--- a/state/state-network.md
+++ b/state/state-network.md
@@ -65,7 +65,15 @@ custom_payload = SSZ.serialize(custom_data)
 
 #### POKE Mechanism
 
-The [POKE Mechanism](./portal-wire-protocol#poke-mechanism) MUST be disabled for the state network. As `content_for_retrieval` is different from `content_for_offer` the POKE mechanism cannot offer content that is verifiable.
+As `content_for_retrieval` is different from `content_for_offer` the POKE mechanism cannot offer content that is verifiable without providing
+the proof/s that are contained in the `content_for_offer` payload. These proofs are usually available when walking down the trie during content
+lookups such as during an `eth_getBalance` JSON-RPC call implemented in the state network.
+
+The [POKE Mechanism](./portal-wire-protocol#poke-mechanism) for the state network requires building a `content_for_offer` by combining the `content_for_retrieval` with the parent proof/s and block hash. This is implemented differently for each
+type of content:
+- For account trie nodes the trie node in the `content_for_retrieval` is appended to the parent account proof and then combined with the block hash to build the `content_for_offer`.
+- For contract trie nodes the trie node in the `content_for_retrieval` is appended to the parent storage proof and then combined with the account proof and block hash to build the `content_for_offer`.
+- For contract code the code in the `content_for_retrieval` is combined with the account proof and block hash to build the `content_for_offer`.
 
 ### Routing Table
 
@@ -340,7 +348,7 @@ something like this (numbers next to branches indicate the index in the branch n
 
 ```
          branch (root)
-       /0             \1 
+       /0             \1
 prefix: 123            prefix: 234
 value:  A              value:  B
 ```

--- a/state/state-network.md
+++ b/state/state-network.md
@@ -75,7 +75,7 @@ type of content:
 - For contract trie nodes the trie node in the `content_for_retrieval` is appended to the parent storage proof and then combined with the account proof and block hash to build the `content_for_offer`.
 - For contract code the code in the `content_for_retrieval` is combined with the account proof and block hash to build the `content_for_offer`.
 
-This POKE mechanism as described above SHOULD be executed after looking up content from the network, whenever the proofs and block hash are available
+This POKE mechanism as described above SHOULD be executed after looking up content from the network, whenever the proofs and block hash are locally available
 to be used to build the `content_for_offer`.
 
 ### Routing Table

--- a/state/state-network.md
+++ b/state/state-network.md
@@ -75,6 +75,9 @@ type of content:
 - For contract trie nodes the trie node in the `content_for_retrieval` is appended to the parent storage proof and then combined with the account proof and block hash to build the `content_for_offer`.
 - For contract code the code in the `content_for_retrieval` is combined with the account proof and block hash to build the `content_for_offer`.
 
+This POKE mechanism as described above SHOULD be executed after looking up content from the network, whenever the proofs and block hash are available
+to be used to build the `content_for_offer`.
+
 ### Routing Table
 
 The execution state network uses the standard routing table structure from the Portal Wire Protocol.


### PR DESCRIPTION
Poke in the state network is feasible by passing in the parent offer when looking up content. The fetched state content is then combined with the parent offer to build the offer which is used in the poke.

I'm not aware of any reason why poke should still be disabled in the state network, so I suggest we re-enable it.