### PR TITLE
Remove one SSZ seralization layer from ping extensions + clean up rest of spec

### DIFF
--- a/SPECIFICATION_TEMPLATE.md
+++ b/SPECIFICATION_TEMPLATE.md
@@ -54,7 +54,7 @@ as "Retrieval of block headers by their hash"
 
 <!-- The list of message types from the portal wire protocol that are supported by this network -->
 
-#### `Ping.custom_data` & `Pong.custom_data`
+#### `Ping.payload` & `Pong.payload`
 
 <!-- If the PING/PONG messages are used by this protocol they should be specified here -->
 

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -74,9 +74,9 @@ The beacon chain network supports the following protocol messages:
 - `Find Content` - `Found Content`
 - `Offer` - `Accept`
 
-#### `Ping.custom_data` & `Pong.custom_data`
+#### `Ping.payload` & `Pong.payload`
 
-In the beacon chain network the `custom_payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
+In the beacon chain network the `payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
 
 List of currently supported payloads, by latest to oldest.
 -  [Type 1 Basic Radius Payload](../ping-payload-extensions/extensions/type-1.md)

--- a/canonical-transaction-index/canonical-transaction-index-network.md
+++ b/canonical-transaction-index/canonical-transaction-index-network.md
@@ -54,9 +54,9 @@ The canonical transaction index network supports the following protocol messages
 - `Offer` - `Accept`
 
 
-#### `Ping.custom_data` & `Pong.custom_data`
+#### `Ping.payload` & `Pong.payload`
 
-In the canonical transaction index network the `custom_payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
+In the canonical transaction index network the `payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
 
 List of currently supported payloads, by latest to oldest.
 -  [Type 1 Basic Radius Payload](../ping-payload-extensions/extensions/type-1.md)

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -59,9 +59,9 @@ The history network supports the following protocol messages:
 - `Find Content` - `Found Content`
 - `Offer` - `Accept`
 
-#### `Ping.custom_data` & `Pong.custom_data`
+#### `Ping.payload` & `Pong.payload`
 
-In the history network the `custom_payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
+In the history network the `payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
 
 List of currently supported payloads, by latest to oldest.
 -  [Type 2 History Radius Payload](../ping-payload-extensions/extensions/type-2.md)

--- a/ping-payload-extensions/extensions/template.md
+++ b/ping-payload-extensions/extensions/template.md
@@ -8,8 +8,9 @@ Ping payload
 [Payload] = SSZ.serialize(Container([Key Value Pairs]))
 
 
-[Container Name] = Container(
-  type: [Type Number],
+Ping Message = Container(
+  enr_seq: uint64,
+  payload_type: [Type Number],
   payload: [Payload]
 )
 ```
@@ -19,8 +20,9 @@ Pong payload
 
 [Payload] = SSZ.serialize(Container([Key Value Pairs]))
 
-[Container Name] = Container(
-  type: [Type Number],
+Pong Message = Container(
+  enr_seq: uint64,
+  payload_type: [Type Number],
   payload: [Payload]
 )
 ```

--- a/ping-payload-extensions/extensions/type-0.md
+++ b/ping-payload-extensions/extensions/type-0.md
@@ -35,7 +35,8 @@ client_info_and_capabilities = SSZ.serialize(Container(
     capabilities: List[u16, MAX_CAPABILITIES_LENGTH]
 ))
 
-CapabilitiesPayload = Container(
+Ping/Pong Message = Container(
+  enr_seq: uint64,
   type: 0,
   payload: client_info_and_capabilities
 )

--- a/ping-payload-extensions/extensions/type-1.md
+++ b/ping-payload-extensions/extensions/type-1.md
@@ -7,7 +7,8 @@ Ping and Pong Payload
 
 basic_radius = SSZ.serialize(Container(data_radius: U256))
 
-BasicRadiusPayload = Container(
+Ping/Pong Message = Container(
+  enr_seq: uint64,    
   type: 1,
   payload: basic_radius
 )

--- a/ping-payload-extensions/extensions/type-2.md
+++ b/ping-payload-extensions/extensions/type-2.md
@@ -7,7 +7,8 @@ Ping and Pong Payload
 
 history_radius = SSZ.serialize(Container(data_radius: U256, ephemeral_header_count=U16))
 
-HistoryRadiusPayload = Container(
+Ping/Pong Message = Container(
+  enr_seq: uint64,    
   type: 2,
   payload: history_radius
 )

--- a/ping-payload-extensions/extensions/type-65535.md
+++ b/ping-payload-extensions/extensions/type-65535.md
@@ -10,7 +10,8 @@ MAX_ERROR_BYTE_LENGTH = 300
 
 error_payload = SSZ.serialize(Container(error_code: u16, message: ByteList[MAX_ERROR_BYTE_LENGTH]))
 
-ErrorPayload = Container(
+Pong Message = Container(
+  enr_seq: uint64,    
   type: 65535,
   payload: error_payload
 )

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -95,7 +95,7 @@ The transmission of `content` data that is too large to fit a single packet is d
 
 #### Ping (0x00)
 
-Request message to check if a node is reachable, communicate basic information about our node, and request basic information about the recipient node.  Additionally sub-protocol can define a schema for the `custom_payload` field to exchange additional information.
+Request message to check if a node is reachable, communicate basic information about our node, and request basic information about the recipient node.  Additionally sub-protocol can define a schema for the `payload` field to exchange additional information.
 
 ```
 selector     = 0x00
@@ -325,7 +325,7 @@ port       := UDP port number
 
 ### Protocol Specific Node State
 
-Sub protocols may define additional node state information which should be tracked in the node state database.  This information will typically be transmitted in the `Ping.custom_data` and `Pong.custom_data` fields.
+Sub protocols may define additional node state information which should be tracked in the node state database.  This information will typically be transmitted in the `Ping.payload` and `Pong.payload` fields.
 
 
 ## Algorithms

--- a/state/state-network.md
+++ b/state/state-network.md
@@ -54,9 +54,9 @@ The execution state network supports the following protocol messages:
 - `Find Content` - `Found Content`
 - `Offer` - `Accept`
 
-#### `Ping.custom_data` & `Pong.custom_data`
+#### `Ping.payload` & `Pong.payload`
 
-In the execution state network network the `custom_payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
+In the execution state network network the `payload` field of the `Ping` and `Pong` messages. The first packet between another client MUST be [Type 0: Client Info, Radius, and Capabilities Payload](../ping-payload-extensions/extensions/type-0.md). Then upgraded to the latest payload supported by both of the clients.
 
 List of currently supported payloads, by latest to oldest.
 -  [Type 1 Basic Radius Payload](../ping-payload-extensions/extensions/type-1.md)

--- a/transaction-gossip/transaction-gossip.md
+++ b/transaction-gossip/transaction-gossip.md
@@ -26,7 +26,7 @@ The network uses the PING/PONG/FINDNODES/FOUNDNODES/OFFER/ACCEPT messages from t
 
 The network uses the standard XOR distance function.
 
-In the execution state network the `custom_payload` field of the `Ping` and `Pong` messages is the serialization of an SSZ Container specified as [Type 1 Basic Radius Payload](../ping-payload-extensions/extensions/type-1.md)
+In the execution state network the `payload` field of the `Ping` and `Pong` messages is the serialization of an SSZ Container specified as [Type 1 Basic Radius Payload](../ping-payload-extensions/extensions/type-1.md)
 
 ## Content Keys
 


### PR DESCRIPTION
I basically just expand on Kim's PR and flesh out the rest of it so it aligns with his idea of removing the extra SSZ serialization layer