### PR TITLE
Add beacon endpoint for finalized state root used in hive

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -8,9 +8,17 @@
   },
   "BeaconOptimisticStateRootResult": {
     "name": "optimisticStateRootResult",
-    "description": "Returns the hex encoded optimistic beacon state root.",
+    "description": "Returns the hex encoded optimistic beacon state root. If the beacon client is not synced, return the error.",
     "schema": {
       "title": "Hex encoded optimistic beacon state root",
+      "$ref": "#/components/schemas/bytes32"
+    }
+  },
+  "BeaconFinalizedStateRootResult": {
+    "name": "finalizedStateRootResult",
+    "description": "Returns the hex encoded finalized beacon state root. If the beacon client is not synced, return the error.",
+    "schema": {
+      "title": "Hex encoded finalized beacon state root",
       "$ref": "#/components/schemas/bytes32"
     }
   },

--- a/jsonrpc/src/errors/errors.json
+++ b/jsonrpc/src/errors/errors.json
@@ -9,5 +9,9 @@
     "data": {
       "$ref": "#/components/schemas/traceResultObject"
     }
-  }    
+  },
+  "BeaconClientNotInitializedError": {
+    "code": -39003,
+    "message": "beacon client not initialized"
+  }
 }

--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -118,7 +118,25 @@
     "params": [],
     "result": {
       "$ref": "#/components/contentDescriptors/BeaconOptimisticStateRootResult"
-    }
+    },
+    "errors": [
+      {
+        "$ref": "#/components/errors/BeaconClientNotInitializedError"
+      }
+    ]
+  },
+  {
+    "name": "portal_beaconFinalizedStateRoot",
+    "summary": "Get latest known finalized beacon state root.",
+    "params": [],
+    "result": {
+      "$ref": "#/components/contentDescriptors/BeaconFinalizedStateRootResult"
+    },
+    "errors": [
+      {
+        "$ref": "#/components/errors/BeaconClientNotInitializedError"
+      }
+    ]
   },
   {
     "name": "portal_beaconRecursiveFindNodes",


### PR DESCRIPTION
A suite of tests were just added to hive that test a client's ability to sync the beacon network. These are the endpoints/behavior that hive expects a client to support to pass the sync tests