### PR TITLE
Add detailed offer decline codes

### DIFF
--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -110,7 +110,7 @@
   },
   "OfferResult": {
     "name": "offerResult",
-    "description": "Returns the content keys bytelist upon successful content transmission or empty bytelist receival",
+    "description": "Returns the accepted content keys bytelist upon successful content transmission or no transmission in case of empty bytelist receival. Return error on response or transmission errors.",
     "schema": {
       "title": "Encoded content keys bytelist",
       "$ref": "#/components/schemas/hexString"

--- a/jsonrpc/src/content/results.json
+++ b/jsonrpc/src/content/results.json
@@ -110,9 +110,9 @@
   },
   "OfferResult": {
     "name": "offerResult",
-    "description": "Returns the content keys bitlist upon successful content transmission or empty bitlist receival",
+    "description": "Returns the content keys bytelist upon successful content transmission or empty bytelist receival",
     "schema": {
-      "title": "Encoded content keys bitlist",
+      "title": "Encoded content keys bytelist",
       "$ref": "#/components/schemas/hexString"
     }
   },

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -392,7 +392,6 @@ The process above should quickly saturate the area of the DHT where the content 
 
 The node can use ACCEPT codes received in past responses to make more efficient choices on which neighbors to gossip to.
 
-
 ### POKE Mechanism
 
 When a node in the network is doing a content lookup, it will practically perform a recursive find using the `FindContent` and `Content` messages.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -390,6 +390,9 @@ offers the content to maximum `n` of the newly discovered nodes.
 
 The process above should quickly saturate the area of the DHT where the content is located and naturally terminate as more nodes become aware of the content.
 
+The node can use ACCEPT codes received in past responses to make more efficient choices on which neighbors to gossip to.
+
+
 ### POKE Mechanism
 
 When a node in the network is doing a content lookup, it will practically perform a recursive find using the `FindContent` and `Content` messages.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -239,12 +239,13 @@ accept       = Container(connection_id: Bytes2, content_keys: ByteList[limit=64]
     - ConnectionID values **SHOULD** be randomly generated.
 - `content_keys`: Signals which content keys are desired.
     - A byte-list corresponding to the offered keys with the byte in the positions of the desired keys set to `1`.
-      - 0: Generic decline, send if there is no specific decline case
+      - 0: Generic decline, catch all if their is no specified case
       - 1: Accept the Content
       - 2: Declined, already store content
       - 3: Declined, inbound content transfer already in progress
       - 4: Declined, due to rate limited
       - 5: Declined, content not within nodes radius
+      - 6..=256: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
 
 Upon *sending* this message, the requesting node **SHOULD** *listen* for an incoming uTP stream with the generated `connection_id`.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -232,7 +232,7 @@ Signals interest in receiving the offered data from the corresponding Offer mess
 
 ```
 selector     = 0x07
-accept       = Container(connection_id: Bytes2, content_keys: ByteList[limit=64]
+accept       = Container(connection_id: Bytes2, content_keys: ByteList[limit=64])
 ```
 
 - `connection_id`: Connection ID to set up a uTP stream to transmit the requested data.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -232,20 +232,20 @@ Signals interest in receiving the offered data from the corresponding Offer mess
 
 ```
 selector     = 0x07
-accept       = Container(connection_id: Bytes2, content_keys: ByteList[limit=64])
+accept       = Container(connection_id: Bytes2, content_keys: ByteList[64])
 ```
 
 - `connection_id`: Connection ID to set up a uTP stream to transmit the requested data.
     - ConnectionID values **SHOULD** be randomly generated.
 - `content_keys`: Signals which content keys are desired.
     - A byte-list corresponding to the offered keys with the byte in the positions of the desired keys set to `1`.
-      - 0: Generic decline, catch all if their is no specified case
-      - 1: Accept the Content
-      - 2: Declined, already store content
-      - 3: Declined, inbound content transfer already in progress
+      - 0: Accept the content
+      - 1: Generic decline, catch all if their is no specified case
+      - 2: Declined, content already stored
+      - 3: Declined, content not within node's radius
       - 4: Declined, due to rate limited
-      - 5: Declined, content not within nodes radius
-      - 6..=256: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
+      - 5: Declined, inbound content transfer already in progress
+      - 6 to 256: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
 
 Upon *sending* this message, the requesting node **SHOULD** *listen* for an incoming uTP stream with the generated `connection_id`.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -232,13 +232,19 @@ Signals interest in receiving the offered data from the corresponding Offer mess
 
 ```
 selector     = 0x07
-accept       = Container(connection_id: Bytes2, content_keys: BitList[limit=64]]
+accept       = Container(connection_id: Bytes2, content_keys: ByteList[limit=64]
 ```
 
 - `connection_id`: Connection ID to set up a uTP stream to transmit the requested data.
     - ConnectionID values **SHOULD** be randomly generated.
 - `content_keys`: Signals which content keys are desired.
-    - A bit-list corresponding to the offered keys with the bits in the positions of the desired keys set to `1`.
+    - A byte-list corresponding to the offered keys with the byte in the positions of the desired keys set to `1`.
+      - 0: Generic decline, send if there is no specific decline case
+      - 1: Accept the Content
+      - 2: Declined, already store content
+      - 3: Declined, inbound content transfer already in progress
+      - 4: Declined, due to rate limited
+      - 5: Declined, content not within nodes radius
 
 Upon *sending* this message, the requesting node **SHOULD** *listen* for an incoming uTP stream with the generated `connection_id`.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -238,13 +238,13 @@ accept       = Container(connection_id: Bytes2, content_keys: ByteList[64])
 - `connection_id`: Connection ID to set up a uTP stream to transmit the requested data.
     - ConnectionID values **SHOULD** be randomly generated.
 - `content_keys`: Signals which content keys are desired.
-    - A byte-list corresponding to the offered keys with the byte in the positions of the desired keys set to `1`.
+    - A byte-list corresponding to the offered keys with the byte in the positions of the desired keys set to `0`.
       - 0: Accept the content
       - 1: Generic decline, catch all if their is no specified case
       - 2: Declined, content already stored
       - 3: Declined, content not within node's radius
       - 4: Declined, total concurrent uTP transfer limit reached
-      - 5: Declined, total inbound content specific transfers already in progress limit reached
+      - 5: Declined, the total inbound rate limit for accepting this specific content_id has been reached
       - 6 to 255: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
 
 Upon *sending* this message, the requesting node **SHOULD** *listen* for an incoming uTP stream with the generated `connection_id`.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -243,8 +243,8 @@ accept       = Container(connection_id: Bytes2, content_keys: ByteList[64])
       - 1: Generic decline, catch all if their is no specified case
       - 2: Declined, content already stored
       - 3: Declined, content not within node's radius
-      - 4: Declined, total concurrent uTP transfer limit reached
-      - 5: Declined, the total inbound rate limit for accepting this specific content_id has been reached
+      - 4: Declined, rate limit reached. Node can't handle anymore connections
+      - 5: Declined, inbound rate limit reached for accepting a specific content_id, used to protect against thundering herds
       - 6 to 255: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
 
 Upon *sending* this message, the requesting node **SHOULD** *listen* for an incoming uTP stream with the generated `connection_id`.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -243,9 +243,9 @@ accept       = Container(connection_id: Bytes2, content_keys: ByteList[64])
       - 1: Generic decline, catch all if their is no specified case
       - 2: Declined, content already stored
       - 3: Declined, content not within node's radius
-      - 4: Declined, due to rate limited
-      - 5: Declined, inbound content transfer already in progress
-      - 6 to 256: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
+      - 4: Declined, total concurrent uTP transfer limit reached
+      - 5: Declined, total inbound content specific transfers already in progress limit reached
+      - 6 to 255: Unspecified decline, this shouldn't be used, but if it is received should just be treated the same as any other decline
 
 Upon *sending* this message, the requesting node **SHOULD** *listen* for an incoming uTP stream with the generated `connection_id`.
 

--- a/portal-wire-test-vectors.md
+++ b/portal-wire-test-vectors.md
@@ -125,10 +125,10 @@ message = 0x060400000004000000010203
 #### Input Parameters
 ```
 connection_id = [0x01, 0x02]
-content_keys = [1, 0, 2, 3, 4, 5, 0, 0] # 8 byte bytelist
+content_keys = [0, 1, 2, 3, 4, 5, 1, 1] # 8 byte bytelist
 ```
 
 #### Expected Output
 ```
-message = 0x070102060000000100020304050000
+message = 0x070102060000000001020304050101
 ```

--- a/portal-wire-test-vectors.md
+++ b/portal-wire-test-vectors.md
@@ -125,10 +125,10 @@ message = 0x060400000004000000010203
 #### Input Parameters
 ```
 connection_id = [0x01, 0x02]
-content_keys = [1, 0, 0, 0, 0, 0, 0, 0] # 8 bits bitlist, 0 bit set = byte 0x01
+content_keys = [1, 0, 2, 3, 4, 5, 0, 0] # 8 byte bytelist
 ```
 
 #### Expected Output
 ```
-message = 0x070102060000000101
+message = 0x070102060000000100020304050000
 ```


### PR DESCRIPTION
A offer can be declined for various reasons, using a generic decline message is very cryptic which makes it immensely hard to understand why we can't find nodes to accept the content, without controlling a majority of the network and logging every single implementation which doesn't make sense due to the complexity.