### PR TITLE
Fix state and beacon portal_*Offer params

### DIFF
--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -209,10 +209,7 @@
             "$ref": "#/components/contentDescriptors/Enr"
         },
         {
-            "$ref": "#/components/contentDescriptors/PayloadType"
-        },
-        {
-            "$ref": "#/components/contentDescriptors/Payload"
+          "$ref": "#/components/contentDescriptors/ContentItems"
         }
     ],
     "result": {

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -209,10 +209,7 @@
             "$ref": "#/components/contentDescriptors/Enr"
         },
         {
-            "$ref": "#/components/contentDescriptors/PayloadType"
-        },
-        {
-            "$ref": "#/components/contentDescriptors/Payload"
+          "$ref": "#/components/contentDescriptors/ContentItems"
         }
     ],
     "result": {


### PR DESCRIPTION
I accidentally copied the `portal_*Ping` params to `portal_*Offer` this PR fixes it  https://github.com/ethereum/portal-network-specs/pull/369#discussion_r1997285499