### PR TITLE
Fix broken relative links for `portal-wire-spec.md` and `beacon-network.md`

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -59,11 +59,11 @@ The beacon chain network uses the SHA256 Content ID derivation function from the
 
 ### Wire Protocol
 
-The [Portal wire protocol](./portal-wire-protocol.md) is used as the wire protocol for the Beacon Chain Light Client network.
+The [Portal wire protocol](../portal-wire-protocol.md) is used as the wire protocol for the Beacon Chain Light Client network.
 
 #### Protocol Identifier
 
-As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x501A`.
+As specified in the [Protocol identifiers](../portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x501A`.
 
 #### Supported Messages Types
 

--- a/canonical-transaction-index/canonical-transaction-index-network.md
+++ b/canonical-transaction-index/canonical-transaction-index-network.md
@@ -5,7 +5,7 @@ This document is the specification for the sub-protocol that supports on-demand 
 
 ## Overview
 
-The canonical transaction index network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](./portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
+The canonical transaction index network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](../portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
 
 The canonical transaction index consists of a mapping from transaction hash to the canonical block hash within which the transaction was included and the index of the transaction within the set of transactions executed within that block.
 
@@ -36,12 +36,12 @@ The canonical transaction index network uses the SHA256 Content ID derivation fu
 
 ### Wire Protocol
 
-The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the canonical transaction index network.
+The [Portal wire protocol](../portal-wire-protocol.md) is used as wire protocol for the canonical transaction index network.
 
 
 #### Protocol Identifier
 
-As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500D`.
+As specified in the [Protocol identifiers](../portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500D`.
 
 
 #### Supported Message Types

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -4,7 +4,7 @@ This document is the specification for the sub-protocol that supports on-demand 
 
 ## Overview
 
-The chain history network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](./portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
+The chain history network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](../portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
 
 Execution chain history data consists of historical block headers, block bodies (transactions, ommers and withdrawals) and block receipts.
 
@@ -44,11 +44,11 @@ The history network uses the SHA256 Content ID derivation function from the port
 
 ### Wire Protocol
 
-The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the history network.
+The [Portal wire protocol](../portal-wire-protocol.md) is used as wire protocol for the history network.
 
 #### Protocol Identifier
 
-As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500B`.
+As specified in the [Protocol identifiers](../portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500B`.
 
 #### Supported Message Types
 
@@ -483,7 +483,7 @@ Additionally the SSZ container holds a `BeaconBlock` hash_tree_root and a slot.
 This chain of two proofs allows for verifying that an EL `BlockHeader` is part of the canonical chain. The only requirement is having access to the beacon chain `historical_summaries`.
 The `historical_summaries` is a [`BeaconState` field](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#beaconstate) that was introduced since the Capella fork. It gets updated every period (8192 slots). The `BlockProofHistoricalSummaries` MUST be used to verify blocks from the Capella fork onwards.
 
-The `historical_summaries` can be taken from the CL `BeaconState` (e.g. via [Beacon API](https://ethereum.github.io/beacon-APIs/#/Debug/getStateV2)) or the Portal beacon network can be used to [provide access](./beacon-chain/beacon-network.md#historicalsummaries) to an up to date `historical_summaries` object."
+The `historical_summaries` can be taken from the CL `BeaconState` (e.g. via [Beacon API](https://ethereum.github.io/beacon-APIs/#/Debug/getStateV2)) or the Portal beacon network can be used to [provide access](../beacon-chain/beacon-network.md#historicalsummaries) to an up to date `historical_summaries` object."
 
 The relationship of the beacon chain structures that are used for the `BlockProofHistoricalSummaries` can be seen below:
 

--- a/state/state-network.md
+++ b/state/state-network.md
@@ -4,7 +4,7 @@ This document is the specification for the sub-protocol that supports on-demand 
 
 ## Overview
 
-The execution state network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](./portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
+The execution state network is a [Kademlia](https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) DHT that uses the [Portal Wire Protocol](../portal-wire-protocol.md) to establish an overlay network on top of the [Discovery v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md) protocol.
 
 State data from the execution chain consists of all account data from the main storage trie, all contract storage data from all of the individual contract storage tries, and the individual bytecodes for all contracts across all historical state roots.  This is traditionally referred to as an "archive node".
 
@@ -43,7 +43,7 @@ The state network uses the SHA256 Content ID derivation function from the portal
 
 #### Protocol Identifier
 
-As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500A`.
+As specified in the [Protocol identifiers](../portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500A`.
 
 #### Supported Message Types
 
@@ -67,7 +67,7 @@ As `content_for_retrieval` is different from `content_for_offer` the POKE mechan
 the proof/s that are contained in the `content_for_offer` payload. These proofs are usually available when walking down the trie during content
 lookups such as during an `eth_getBalance` JSON-RPC call implemented in the state network.
 
-The [POKE Mechanism](./portal-wire-protocol#poke-mechanism) for the state network requires building a `content_for_offer` by combining the `content_for_retrieval` with the parent proof/s and block hash. This is implemented differently for each
+The [POKE Mechanism](../portal-wire-protocol#poke-mechanism) for the state network requires building a `content_for_offer` by combining the `content_for_retrieval` with the parent proof/s and block hash. This is implemented differently for each
 type of content:
 - For account trie nodes the trie node in the `content_for_retrieval` is appended to the parent account proof and then combined with the block hash to build the `content_for_offer`.
 - For contract trie nodes the trie node in the `content_for_retrieval` is appended to the parent storage proof and then combined with the account proof and block hash to build the `content_for_offer`.

--- a/transaction-gossip/transaction-gossip.md
+++ b/transaction-gossip/transaction-gossip.md
@@ -15,11 +15,11 @@ The transaction gossip network is designed with the following requirements.
 
 ## Wire Protocol
 
-The [Portal wire protocol](./portal-wire-protocol.md) is used as wire protocol for the transaction gossip network.
+The [Portal wire protocol](../portal-wire-protocol.md) is used as wire protocol for the transaction gossip network.
 
-As specified in the [Protocol identifiers](./portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500C`.
+As specified in the [Protocol identifiers](../portal-wire-protocol.md#protocol-identifiers) section of the Portal wire protocol, the `protocol` field in the `TALKREQ` message **MUST** contain the value of `0x500C`.
 
-The network uses the PING/PONG/FINDNODES/FOUNDNODES/OFFER/ACCEPT messages from the [Portal Wire Protocol](./portal-wire-protocol.md).
+The network uses the PING/PONG/FINDNODES/FOUNDNODES/OFFER/ACCEPT messages from the [Portal Wire Protocol](../portal-wire-protocol.md).
 
 
 ### Distance Function


### PR DESCRIPTION
fixes https://github.com/ethereum/portal-network-specs/issues/376 but this problem was also in quite a bit more places so I fixed it wherever I seen it happening.