### PR TITLE
Fix add missing .md's to file links

### DIFF
--- a/implementation-details-overlay.md
+++ b/implementation-details-overlay.md
@@ -22,7 +22,7 @@ The ability to send a TALKREQ with a specific `request_id` and receive the corre
 
 # B - Portal Wire Protocol Messages
 
-Support for the message types that are part of the [portal wire protocol](./portal-wire-protocol)
+Support for the message types that are part of the [portal wire protocol](./portal-wire-protocol.md)
 
 ## B.1 - PING & PONG
 

--- a/state/state-network.md
+++ b/state/state-network.md
@@ -67,7 +67,7 @@ As `content_for_retrieval` is different from `content_for_offer` the POKE mechan
 the proof/s that are contained in the `content_for_offer` payload. These proofs are usually available when walking down the trie during content
 lookups such as during an `eth_getBalance` JSON-RPC call implemented in the state network.
 
-The [POKE Mechanism](../portal-wire-protocol#poke-mechanism) for the state network requires building a `content_for_offer` by combining the `content_for_retrieval` with the parent proof/s and block hash. This is implemented differently for each
+The [POKE Mechanism](../portal-wire-protocol.md#poke-mechanism) for the state network requires building a `content_for_offer` by combining the `content_for_retrieval` with the parent proof/s and block hash. This is implemented differently for each
 type of content:
 - For account trie nodes the trie node in the `content_for_retrieval` is appended to the parent account proof and then combined with the block hash to build the `content_for_offer`.
 - For contract trie nodes the trie node in the `content_for_retrieval` is appended to the parent storage proof and then combined with the account proof and block hash to build the `content_for_offer`.


### PR DESCRIPTION
I found another issue with linking files, this one only affects viewing on github, unlike my last PR. Without `.md` works on my local Markdown reader, but not on github's so without `.md` these 2 show 404 pages while viewing on github.

So https://github.com/ethereum/portal-network-specs/issues/376 wasn't working for 2 distinct issues I guess