### PR TITLE
Add protocol versioning to the specification

### DIFF
--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -12,7 +12,7 @@ Unsupported messages **SHOULD** receive a `TALKRESP` message with an empty paylo
 
 ## Protocol Version
 
-The portal wire protocol is versioned using unsigned integers.  The current version is `1`.
+The portal wire protocol is versioned using unsigned integers.  The current version is `2`.
 
 Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -14,7 +14,7 @@ Unsupported messages **SHOULD** receive a `TALKRESP` message with an empty paylo
 
 The portal wire protocol is versioned using unsigned integers.  The current version is `2`.
 
-Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.
+Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.  If this field is missing from the ENR it should be assumed that the client only supports version `1` of the protocol.
 
 Clients should communicate with each other using the highest mutually supported protocol version.  Exchange of ENR records for negotiating protocol version is done using the base DiscoverV5 protocol.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -10,6 +10,16 @@ Sub-protocol using the wire protocol **MAY** choose to exclude certain message t
 
 Unsupported messages **SHOULD** receive a `TALKRESP` message with an empty payload.
 
+## Protocol Version
+
+The portal wire protocol is versioned using whole number versins.  The current version is `1`.
+
+Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.
+
+Clients should communicate with each other using the highest mutually supported protocol version.  Exchange of ENR records for negotiating protocol version is done using the base DiscoverV5 protocol.
+
+Changes to the protocol that increment the version number should be recorded in the [Changelog](./protocol-version-changelog.md)
+
 ## Protocol identifiers
 
 All protocol identifiers consist of two bytes. The first byte is "`P`" (`0x50`), to indicate "the Portal network", the second byte is a specific network identifier.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -12,9 +12,9 @@ Unsupported messages **SHOULD** receive a `TALKRESP` message with an empty paylo
 
 ## Protocol Version
 
-The portal wire protocol is versioned using unsigned integers.  The current version is `2`.
+The portal wire protocol is versioned using unsigned integers.  The current version is `1`.
 
-Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.  If this field is missing from the ENR it should be assumed that the client only supports version `1` of the protocol.
+Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.  If this field is missing from the ENR it should be assumed that the client only supports version `0` of the protocol.
 
 Clients should communicate with each other using the highest mutually supported protocol version.  Exchange of ENR records for negotiating protocol version is done using the base DiscoverV5 protocol.
 

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -12,7 +12,7 @@ Unsupported messages **SHOULD** receive a `TALKRESP` message with an empty paylo
 
 ## Protocol Version
 
-The portal wire protocol is versioned using whole number versins.  The current version is `1`.
+The portal wire protocol is versioned using unsigned integers.  The current version is `1`.
 
 Support for protocol versions is signaled through the ENR record under the key `pv`.  The value should be a serialized SSZ object with the schema `List[uint8, limit=8]` whos value are the list of supported protocol versions.
 

--- a/protocol-version-changelog.md
+++ b/protocol-version-changelog.md
@@ -2,4 +2,9 @@
 
 ## Version 1
 
-Initial versioning of the protocol.  No changes.
+Initial versioning of the protocol.
+
+
+## Version 2
+
+- https://github.com/ethereum/portal-network-specs/pull/370 - Add detailed offer decline codes.

--- a/protocol-version-changelog.md
+++ b/protocol-version-changelog.md
@@ -1,0 +1,5 @@
+# Wire Protocol Changelog
+
+## Version 1
+
+Initial versioning of the protocol.  No changes.

--- a/protocol-version-changelog.md
+++ b/protocol-version-changelog.md
@@ -1,10 +1,10 @@
 # Wire Protocol Changelog
 
-## Version 1
+## Version 0
 
 Initial versioning of the protocol.
 
 
-## Version 2
+## Version 1
 
 - https://github.com/ethereum/portal-network-specs/pull/370 - Add detailed offer decline codes.


### PR DESCRIPTION
## What is wrong

In the near term future, the network will no longer be run solely by "us".  In this world, we need a network that allows us to roll out breaking changes without negatively impacting the health of the network.  For this, our clients need to be able to support multiple versions of the protocol concurrently.

## How was it fixed

Adding protocol versioning, and a mechanism for clients to signal and negotiate supported versions of the protocol.