### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
         working-directory: ./jsonrpc
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 15
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Artifact Actions v3 will be deprecated by January 30, 2025. GitHub has started temporarily failing workflows that haven't been updated ahead of this deadline. This PR updates the action versions accordingly, following the [official migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).