### PR TITLE
Move `Neighborhood Gossip`'s `RecursiveFindNodes` requirement to `portal_*PutContent`

### DIFF
--- a/jsonrpc/src/methods/beacon.json
+++ b/jsonrpc/src/methods/beacon.json
@@ -322,7 +322,7 @@
   },
   {
     "name": "portal_beaconPutContent",
-    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers using the client's default gossip mechanisms.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to `n` interested peers using the client's default gossip mechanisms. If fewer than `n` interested nodes are found in the local DHT, the client launches a node lookup with target `content-id` and it offers the content to maximum `n` of the newly discovered nodes.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/history.json
+++ b/jsonrpc/src/methods/history.json
@@ -296,7 +296,7 @@
   },
   {
     "name": "portal_historyPutContent",
-    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers using the client's default gossip mechanisms.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to `n` interested peers using the client's default gossip mechanisms. If fewer than `n` interested nodes are found in the local DHT, the client launches a node lookup with target `content-id` and it offers the content to maximum `n` of the newly discovered nodes.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/jsonrpc/src/methods/state.json
+++ b/jsonrpc/src/methods/state.json
@@ -290,7 +290,7 @@
   },
   {
     "name": "portal_statePutContent",
-    "summary": "Store the content in the local database if storage criteria is met, then send the content to interested peers using the client's default gossip mechanisms.",
+    "summary": "Store the content in the local database if storage criteria is met, then send the content to `n` interested peers using the client's default gossip mechanisms. If fewer than `n` interested nodes are found in the local DHT, the client launches a node lookup with target `content-id` and it offers the content to maximum `n` of the newly discovered nodes.",
     "params": [
       {
         "$ref": "#/components/contentDescriptors/ContentKey"

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -412,8 +412,7 @@ The process works as follows:
 - A DHT node is offered and receives a piece of content that it is interested in.
 - This DHT node checks their routing table for `k` nearby DHT nodes that should also be interested in the content. Those `k` nodes **SHOULD** not include the node that originally provided aforementioned content.
 - If the DHT node finds `n` or more DHT nodes interested it selects `n` of these nodes and offers the content to them.
-- If the DHT node finds less than `n` DHT nodes interested, it launches a node lookup with target `content-id` and it
-offers the content to maximum `n` of the newly discovered nodes.
+- If fewer than `n` interested nodes are found, it offers the content to as many of them as possible.
 
 The process above should quickly saturate the area of the DHT where the content is located and naturally terminate as more nodes become aware of the content.
 


### PR DESCRIPTION
We/Trin don't implement this `RecursiveFindNodes requirement`, I noticed this during the Portal Summit. I don't think we should launch a RecursiveFindNodes to continue the `Neighborhood gossip`.

- I don't think it is needed to successfully perform `Neighborhood gossip`
- Doing `RecursiveFindNodes` would cause delays in propagating the data, which we should be able to propagate a BlockBody/Receipt across the whole network in 4 seconds or less.

Your Neighborhood would have the best view of the your Neighborhood, so I think it is counterproductive to RFN your neighborhood, when simply doing `Neighborhood gossip` would achieve the same end result, but without using RFN.

If a node knows less then N nodes, then it probably received content far from the contents Neighborhood due to the node having a large radius, which in that case I don't think it makes sense to do RFN as then we wouldn't be doing `Neighborhood gossip`, we would be doing `worldwide gossip` :grin: 