### PR TITLE
Update CI to use actions/setup-node@v4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 15
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
       - run: npm ci


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use actions/setup-node@v4, the latest version of the Node.js setup action.
It provides improved compatibility with recent Node.js versions and includes the latest performance and security improvements.

Confirmed latest version: [actions/setup-node@v4.4.0](https://github.com/actions/setup-node/releases/tag/v4.4.0)