### PR TITLE
Add HistoricalSummariesWithProof for Electra

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -214,15 +214,32 @@ and then use that slot as a starting point for retrieving the most recent update
 Latest `HistoricalSummariesWithProof` object is stored in the network every epoch, even though the `historical_summaries` only updates every period (8192 slots). This is done to have an up to date proof every epoch, which makes it easier to verify the `historical_summaries` when starting the beacon light client sync.
 
 ```python
-HistoricalSummariesProof = Vector[Bytes32, 5]
+HISTORICAL_SUMMARIES_GINDEX_CAPELLA* = get_generalized_index(capella.BeaconState, 'historical_summaries') # = 59
+HISTORICAL_SUMMARIES_GINDEX_ELECTRA* = get_generalized_index(BeaconState, 'historical_summaries') # = 91
 
-historical_summaries_with_proof = HistoricalSummariesWithProof(
+HistoricalSummariesProofCapella = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_CAPELLA)]
+HistoricalSummariesProofElectra = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_ELECTRA)]
+
+# HistoricalSummary object is defined in consensus specs:
+# https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
+
+HistoricalSummariesWithProofCapella = Container(
     epoch: uint64,
-    # HistoricalSummary object is defined in consensus specs:
-    # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
     historical_summaries: List(HistoricalSummary, limit=HISTORICAL_ROOTS_LIMIT),
-    proof: HistoricalSummariesProof
+    proof: HistoricalSummariesProofCapella
 )
+
+HistoricalSummariesWithProofElectra = Container(
+    epoch: uint64,
+    historical_summaries: List(HistoricalSummary, limit=HISTORICAL_ROOTS_LIMIT),
+    proof: HistoricalSummariesProofElectra
+)
+
+# For Capella + Deneb:
+historical_summaries_with_proof = HistoricalSummariesWithProofCapella(...)
+
+# For Electra and onwards:
+historical_summaries_with_proof = HistoricalSummariesWithProofElectra(...)
 
 historical_summaries_key   = Container(epoch: uint64)
 selector                   = 0x14

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -217,32 +217,18 @@ Latest `HistoricalSummariesWithProof` object is stored in the network every epoc
 
 # Definition of generalized index (gindex):
 # https://github.com/ethereum/consensus-specs/blob/d8cfdf2626c1219a40048f8fa3dd103ae8c0b040/ssz/merkle-proofs.md#generalized-merkle-tree-index
-HISTORICAL_SUMMARIES_GINDEX_CAPELLA* = get_generalized_index(capella.BeaconState, 'historical_summaries') # = 59
 HISTORICAL_SUMMARIES_GINDEX_ELECTRA* = get_generalized_index(BeaconState, 'historical_summaries') # = 91
 
-HistoricalSummariesProofCapella = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_CAPELLA)]
 HistoricalSummariesProof = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_ELECTRA)]
 
-# HistoricalSummary object is defined in consensus specs:
-# https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
-
-HistoricalSummariesWithProofCapella = Container(
+# For Electra and onwards:
+historical_summaries_with_proof = Container(
     epoch: uint64,
-    historical_summaries: List(HistoricalSummary, limit=HISTORICAL_ROOTS_LIMIT),
-    proof: HistoricalSummariesProofCapella
-)
-
-HistoricalSummariesWithProof = Container(
-    epoch: uint64,
+    # HistoricalSummary object is defined in consensus specs:
+    # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
     historical_summaries: List(HistoricalSummary, limit=HISTORICAL_ROOTS_LIMIT),
     proof: HistoricalSummariesProof
 )
-
-# For Capella + Deneb (to be deprecated after the Electra fork):
-historical_summaries_with_proof = HistoricalSummariesWithProofCapella(...)
-
-# For Electra and onwards:
-historical_summaries_with_proof = HistoricalSummariesWithProof(...)
 
 historical_summaries_key   = Container(epoch: uint64)
 selector                   = 0x14

--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -214,11 +214,14 @@ and then use that slot as a starting point for retrieving the most recent update
 Latest `HistoricalSummariesWithProof` object is stored in the network every epoch, even though the `historical_summaries` only updates every period (8192 slots). This is done to have an up to date proof every epoch, which makes it easier to verify the `historical_summaries` when starting the beacon light client sync.
 
 ```python
+
+# Definition of generalized index (gindex):
+# https://github.com/ethereum/consensus-specs/blob/d8cfdf2626c1219a40048f8fa3dd103ae8c0b040/ssz/merkle-proofs.md#generalized-merkle-tree-index
 HISTORICAL_SUMMARIES_GINDEX_CAPELLA* = get_generalized_index(capella.BeaconState, 'historical_summaries') # = 59
 HISTORICAL_SUMMARIES_GINDEX_ELECTRA* = get_generalized_index(BeaconState, 'historical_summaries') # = 91
 
 HistoricalSummariesProofCapella = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_CAPELLA)]
-HistoricalSummariesProofElectra = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_ELECTRA)]
+HistoricalSummariesProof = Vector[Bytes32, floorlog2(HISTORICAL_SUMMARIES_GINDEX_ELECTRA)]
 
 # HistoricalSummary object is defined in consensus specs:
 # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary.
@@ -229,17 +232,17 @@ HistoricalSummariesWithProofCapella = Container(
     proof: HistoricalSummariesProofCapella
 )
 
-HistoricalSummariesWithProofElectra = Container(
+HistoricalSummariesWithProof = Container(
     epoch: uint64,
     historical_summaries: List(HistoricalSummary, limit=HISTORICAL_ROOTS_LIMIT),
-    proof: HistoricalSummariesProofElectra
+    proof: HistoricalSummariesProof
 )
 
-# For Capella + Deneb:
+# For Capella + Deneb (to be deprecated after the Electra fork):
 historical_summaries_with_proof = HistoricalSummariesWithProofCapella(...)
 
 # For Electra and onwards:
-historical_summaries_with_proof = HistoricalSummariesWithProofElectra(...)
+historical_summaries_with_proof = HistoricalSummariesWithProof(...)
 
 historical_summaries_key   = Container(epoch: uint64)
 selector                   = 0x14


### PR DESCRIPTION
The proof for the historical_summaries field in the BeaconState changes for Electra.

We need to support both types of proof. But I think after the fork we can actually remove the old one as it makes no sense to provide still the older `historical_summaries`.
Not sure if I should use the naming as I did now due to this.