### PR TITLE
docs: clarify ephemeral headers always include padding

### DIFF
--- a/history/history-network.md
+++ b/history/history-network.md
@@ -320,7 +320,7 @@ Bridges **MUST** send `Offer` messages that contain content keys of three concep
 * If a re-org occurred, then the headers back to the common ancestor block from a previous offer are included
 * An additional `8` header's content keys, MUST be included in the `Offer` message as padding
 * Often, bridge updates will inclued 1 new header, 0 re-org headers, and 8 padding headers
-* If bridges detect a re-org, and padding depth is larger then 31 content keys, additional `Offer` messages containing the rest of the chain should be sent by the bridge in 10 second intervals of the initial `Offer` message, until the common ancestor is reached
+* If there are more than 31 content keys to offer, additional `Offer` messages containing the rest of the chain should be sent by the bridge in 10 second intervals of the initial `Offer` message
 * These categories are only conceptual. The series of header keys offered are concatenated and not identified as belonging to any category.
 
 Details for clients

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -315,13 +315,10 @@ An `Offer` message containing ephemeral headers **MUST**
 * Ephemeral header content keys offered to the client **MUST** be in a strictly consecutive descending order by `block_number`
 * An `Offer` message can only contain up to 31 ephemeral header content keys
 
-Bridges **MUST** send `Offer` messages that contain content keys of three conceptual categories: new, re-org, and padding
-* New headers are defined by the latest tip as specified by `LightClientUpdates`, which have not been broadcast before
-* If a re-org occurred, then the headers back to the common ancestor block from a previous offer are included
-* An additional `8` header's content keys, MUST be included in the `Offer` message as padding
-* Often, bridge updates will inclued 1 new header, 0 re-org headers, and 8 padding headers
-* If there are more than 31 content keys to offer, additional `Offer` messages containing the rest of the chain should be sent by the bridge in 10 second intervals of the initial `Offer` message
-* These categories are only conceptual. The series of header keys offered are concatenated and not identified as belonging to any category.
+Bridges **MUST** send `Offer` messages that
+* Contain content keys for the latest header as specified by `LightClientUpdates`, headers corresponding to the re-org depth since the last broadcast, and 8 additional headers which serve as padding
+* A common case would be 1 new header, 0 re-org headers, and 8 headers for padding
+* If there are more than 31 content keys to offer, additional `Offer` messages containing the rest of the series should be sent by the bridge in 10 second intervals of the initial `Offer` message
 
 Details for clients
 * When offered ephemeral headers, clients should scan the content keys for a `block_hash` anchored via the external oracle. All headers preceding the anchored header in the content keys list **MUST** be treated as its direct ancestors in order of decreasing height.

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -315,8 +315,13 @@ An `Offer` message containing ephemeral headers **MUST**
 * Ephemeral header content keys offered to the client **MUST** be in a strictly consecutive descending order by `block_number`
 * An `Offer` message can only contain up to 31 ephemeral header content keys
 
-Bridges **MUST** send `Offer` messages that
-* Contain content keys from the latest tip as specified by `LightClientUpdates` to the common ancestor block if a re-org occurred. So normally this would be 1 header, unless a re-org occurred where multiple would be included. An additional `8` header's content keys, MUST be included in the `Offer` message as padding. If bridges detect a re-org + padding depth is larger then 31 content keys, additional `Offer` messages containing the rest of the chain should be sent by the bridge in 10 second intervals of the initial `Offer` message
+Bridges **MUST** send `Offer` messages that contain content keys of three conceptual categories: new, re-org, and padding
+* New headers are defined by the latest tip as specified by `LightClientUpdates`, which have not been broadcast before
+* If a re-org occurred, then the headers back to the common ancestor block from a previous offer are included
+* An additional `8` header's content keys, MUST be included in the `Offer` message as padding
+* Often, bridge updates will inclued 1 new header, 0 re-org headers, and 8 padding headers
+* If bridges detect a re-org, and padding depth is larger then 31 content keys, additional `Offer` messages containing the rest of the chain should be sent by the bridge in 10 second intervals of the initial `Offer` message, until the common ancestor is reached
+* These categories are only conceptual. The series of header keys offered are concatenated and not identified as belonging to any category.
 
 Details for clients
 * When offered ephemeral headers, clients should scan the content keys for a `block_hash` anchored via the external oracle. All headers preceding the anchored header in the content keys list **MUST** be treated as its direct ancestors in order of decreasing height.


### PR DESCRIPTION
Just saw this conversation, and figured I would suggest a change to avoid future ambiguity:

> deme: Ah, so this +8 padding is in every case? That is, also just a single block update? I had not interpreted the text like that before, but I can see that now.
> [1:06 PM] deme: I guess it makes sense, normally nodes would not accept all those anyhow.
> [1:09 PM] deme: "So normally this would be 1 header, unless a re-org occurred where multiple would be included. An additional 8 header's content keys, MUST be included in the Offer message as padding."

> This sentence made me originally interpret it as minimum 8 additional headers when a re-org occurred.
> [1:10 PM] Kolby ML: It is more so 1 + re-org-depth + 8
> [1:10 PM] Kolby ML: So most of the time the re-org-depth would be 0 
> [1:10 PM] deme: Ah, I see.