### PR TITLE
beacon: UpdatesByRange don't have to be full, clarify FindContent logic

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -214,7 +214,7 @@ to reject an `LightClientOptimisticUpdate` in case it is not newer than the one 
 >
 > For `FindContent` requests, nodes SHOULD request `optimistic_slot` that is one higher than the
 one they already have. When responding to `FindContent` requests, nodes SHOULD respond with latest
-`LightClientOptimisticUpdate` that they have. If then can't provide the requested or newer object,
+`LightClientOptimisticUpdate` that they have. If they can't provide the requested or newer object,
 they MUST NOT reply with any content.
 
 #### HistoricalSummaries


### PR DESCRIPTION
Updating the beacon spec as agreed during last team call (see [agenda](https://github.com/ethereum/pm/issues/1525) and [call notes](https://hackmd.io/ynlSQZG9QNaDPR2qhRZ2TA?view#May-12th-2025---Call-55)).

- response to `LightClientUpdatesByRange` doesn't have to contain all requested updates, but updates that are in the response must start at the beginning of the requested range and must be consecutive
-  `LightClientOptimisticUpdate` and `LightClientFinalityUpdate` update should be requested for the first missing slot, and reply should always be the latest available (as long as it's not older than the requested one)