### PR TITLE
Specify that ephemeral headers should use random gossip

### DIFF
--- a/beacon-chain/beacon-network.md
+++ b/beacon-chain/beacon-network.md
@@ -100,8 +100,7 @@ When a node cannot fulfill a request for any of this data it SHOULD return an
 empty list of ENRs. It MAY return a list of ENRs of nodes that have provided
 this data in the past.
 
-When a node gossips any of this data, it MUST use [random gossip](./beacon-network.md/#random-gossip) instead of neighborhood gossip.
-
+When a node gossips any of this data, it MUST use [random gossip](../portal-wire-protocol.md#random-gossip) instead of neighborhood gossip.
 
 #### Data Radius
 
@@ -259,16 +258,6 @@ finalized `BeaconState` root.
 `BeaconState`. On finalization, a bridge MUST gossip the `LightClientFinalityUpdate` before the `HistoricalSummariesWithProof` in order for receiving nodes to be able to verify the latter.
 
 ### Algorithms
-
-#### Random Gossip
-
-We use the term *random gossip* to refer to the process through which content is disseminated to a random set DHT nodes.
-
-The process works as follows:
-- A DHT node is offered piece of content that is specified to be gossiped via
-random gossip.
-- The node selects a random node from a random bucket and does this for `n` nodes.
-- The node offers the content to the `n` selected nodes.
 
 #### Validation
 

--- a/history/history-network.md
+++ b/history/history-network.md
@@ -85,6 +85,8 @@ A node is expected to maintain `radius` information for each node in its local n
 
 A node should track their own radius value and provide this value in all Ping or Pong messages it sends to other nodes.
 
+A node MUST use `radius` and [neighborhood gossip](../portal-wire-protocol.md#neighborhood-gossip) to gossip all non-ephemeral content. For gossiping the Ephemeral content, a node MUST use [random gossip](../portal-wire-protocol.md#random-gossip) instead.
+
 ### Data Types
 
 #### Constants
@@ -322,7 +324,7 @@ Bridges **MUST** send `Offer` messages that
 
 Details for clients
 * When offered ephemeral headers, clients should scan the content keys for a `block_hash` anchored via the external oracle. All headers preceding the anchored header in the content keys list **MUST** be treated as its direct ancestors in order of decreasing height.
-* The client accepting an Offer **MUST** neighborhood gossip the headers from the accepted anchored header to the end of the content keys list, even if the client only accepts a subset of the respective range.
+* The client accepting an Offer **MUST** random gossip the headers from the accepted anchored header to the end of the content keys list, even if the client only accepts a subset of the respective range.
 
 Validation Logic
 * When processing accepted headers, if the requested range cannot be validated by walking backward through the header's `parent_hash`'s, clients MAY penalize or descore the peer.

--- a/portal-wire-protocol.md
+++ b/portal-wire-protocol.md
@@ -429,6 +429,16 @@ The process above should quickly saturate the area of the DHT where the content 
 
 The node can use ACCEPT codes received in past responses to make more efficient choices on which neighbors to gossip to.
 
+#### Random Gossip
+
+We use the term *random gossip* to refer to the process through which content is disseminated to a random set DHT nodes.
+
+The process works as follows:
+- A DHT node is offered piece of content that is specified to be gossiped via
+random gossip.
+- The node selects a random node from a random bucket and does this for `n` nodes.
+- The node offers the content to the `n` selected nodes.
+
 ### POKE Mechanism
 
 When a node in the network is doing a content lookup, it will practically perform a recursive find using the `FindContent` and `Content` messages.


### PR DESCRIPTION
Add a clarification that ephemeral content should be gossiped using random gossip algorithm.

I moved existing random gossip algorithm out of beacon network spec, and into portal-wire-protocol (next to neighborhood gossip)

Since some concerns were raised regarding efficiency of the algorithm the selects peers completely randomly, I created #404 that explores alternatives. Updating random gossip spec can be done in a separate PR, once we reach agreement.