### PR TITLE
Update GitHub Actions setup-node to v5

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js 15
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '16'
       - run: npm ci


### PR DESCRIPTION
Bumped actions/setup-node from v4 → v5
Using the latest version ensures continued support, bug fixes, and compatibility improvements.

Official release: https://github.com/actions/setup-node/releases/tag/v5.0.0