### PR TITLE
Update GitHub Action to setup-node@v6

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js 15
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '16'
       - run: npm ci


### PR DESCRIPTION
 actions/setup-node@v5 → uses: actions/setup-node@v6

Reason:
Version v6 includes improved dependency caching, enhanced Node.js version management, and better performance on GitHub-hosted runners.

actions/setup-node@v6.0.0: https://github.com/actions/setup-node/releases/tag/v6.0.0