### PR TITLE
Upgrade setup-node action to v6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
This pull request updates our workflow to use the latest version of the official actions/setup-node action.
The upgrade ensures continued compatibility with GitHub Actions’ hosted runners and takes advantage of recent improvements and security updates introduced in v6.